### PR TITLE
Add support for forward refs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 import pytest
 
 from templatey.templates import _PENDING_FORWARD_REFS
+from templatey.templates import anchor_closure_scope
 
 
 def pytest_addoption(parser):
@@ -35,3 +36,12 @@ def clean_pending_forward_refs_registry():
         yield
     finally:
         _PENDING_FORWARD_REFS.reset(token)
+
+
+@pytest.fixture(autouse=True, scope='function')
+def apply_anchor_closure_scope():
+    """Makes sure that all test functions have a new closure scope, so
+    they work correctly with closures.
+    """
+    with anchor_closure_scope():
+        yield

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,3 +131,7 @@ pythonVersion = "3.13"
 pythonPlatform = "Linux"
 # If you run into import issues, see:
 # https://github.com/microsoft/pyright/blob/main/docs/import-resolution.md
+
+reportUnknownVariableType = "information"
+reportUnknownMemberType = "information"
+ 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,12 @@ readme = "README.md"
 
 dependencies = [
     "docnote>=2025.5.26.1",
-    "typing_extensions>=4.12.2; python_version < '3.13'",
+    "typing_extensions>=4.12.2",
+    # I really wanted to restrict this to ONLY the situations where it's
+    # required, but I can't get pyright to work correctly that way. Either it
+    # complains about the stdlib import or the typing_extensions import, and
+    # adding a type: ignore causes the TypeIs to always be ``Unknown``.
+    # "typing_extensions>=4.12.2; python_version < '3.13'",
 ]
 
 [project.optional-dependencies]

--- a/src_py/templatey/environments.py
+++ b/src_py/templatey/environments.py
@@ -301,9 +301,9 @@ class RenderEnvironment:
         raises MismatchedTemplateSignature.
         """
         template_signature = template_class._templatey_signature
-        variable_names = set(template_signature.vars_)
-        slot_names = set(template_signature.slots)
-        content_names = set(template_signature.content)
+        variable_names = template_signature.var_names
+        slot_names = template_signature.slot_names
+        content_names = template_signature.content_names
 
         if strict_mode:
             variables_mismatch = (

--- a/src_py/templatey/exceptions.py
+++ b/src_py/templatey/exceptions.py
@@ -51,6 +51,12 @@ class MismatchedTemplateSignature(InvalidTemplate):
     """
 
 
+class UnresolvedForwardReference(Exception):
+    """Raised when you attempt to render a template containing a forward
+    reference that was still unresolvable at render time.
+    """
+
+
 class IncompleteTemplateParams(TypeError):
     """Raised when an ellipsis is still present in either slots or
     variables at render time.

--- a/src_py/templatey/parser.py
+++ b/src_py/templatey/parser.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from dataclasses import field
 from dataclasses import fields
 from functools import singledispatch
+from typing import Any
 from typing import cast
 
 from templatey.exceptions import DuplicateSlotName
@@ -511,7 +512,7 @@ def _extract_call_signature(str_signature):
 
 
 @singledispatch
-def _extract_reference_or_literal(ast_node):
+def _extract_reference_or_literal(ast_node) -> Any:
     """Gets the actual reference out of an AST node used in the call
     signature, either as an arg or the value of a kwarg.
     """

--- a/src_py/templatey/renderer.py
+++ b/src_py/templatey/renderer.py
@@ -287,8 +287,8 @@ class _RenderContext:
         # check for membership, so we might as well keep it a list
         template_backlog_local_roots = [root_template]
         template_backlog_included_classes = set(
-            root_template_xable._templatey_signature.included_template_classes)
-        template_backlog_included_classes.add(type(root_template))
+            root_template_xable
+            ._templatey_signature.included_template_classes)
         function_backlog = []
         template_preload = self.template_preload
         function_precall = self.function_precall
@@ -392,8 +392,6 @@ class _RenderContext:
                     template_backlog_included_classes.update(
                         injected_xable._templatey_signature
                         .included_template_classes)
-                    template_backlog_included_classes.add(
-                        type(injected_template))
 
 
 type _PrecallExecutionRequest = tuple[

--- a/src_py/templatey/renderer.py
+++ b/src_py/templatey/renderer.py
@@ -64,7 +64,10 @@ class FuncExecutionResult:
         if self.retval is not None:
             for item in self.retval:
                 if is_template_instance(item):
-                    # Hmm, somehow the TypeIs isn't working
+                    # This doesn't fully work; because of the missing
+                    # intersection type, there's nothing linking the xable that
+                    # this checks for with the params instance that the type
+                    # expects us to yield back
                     yield item  # type: ignore
 
 

--- a/src_py/templatey/renderer.py
+++ b/src_py/templatey/renderer.py
@@ -111,8 +111,8 @@ def render_driver(  # noqa: C901, PLR0912, PLR0915
             signature=template_xable._templatey_signature,
             provenance=TemplateProvenance((
                 TemplateProvenanceNode(
-                    parent_slot_key='',
-                    parent_slot_index=-1,
+                    encloser_slot_key='',
+                    encloser_slot_index=-1,
                     instance_id=id(template_instance),
                     instance=template_instance),)),
             instance=template_instance,
@@ -211,8 +211,8 @@ def render_driver(  # noqa: C901, PLR0912, PLR0915
                         signature=slot_instance._templatey_signature,
                         provenance=TemplateProvenance(
                             (*render_node.provenance, TemplateProvenanceNode(
-                                parent_slot_key=next_part.name,
-                                parent_slot_index=next(provenance_counter),
+                                encloser_slot_key=next_part.name,
+                                encloser_slot_index=next(provenance_counter),
                                 instance_id=id(slot_instance),
                                 instance=slot_instance))),
                         prerenderers=slot_instance._templatey_prerenderers)
@@ -566,8 +566,8 @@ def _build_render_stack_extension(
                     signature=template_xable._templatey_signature,
                     provenance=TemplateProvenance((
                         TemplateProvenanceNode(
-                            parent_slot_key='',
-                            parent_slot_index=-1,
+                            encloser_slot_key='',
+                            encloser_slot_index=-1,
                             instance_id=id(func_result_part),
                             instance=func_result_part),)),
                     instance=func_result_part,

--- a/src_py/templatey/templates.py
+++ b/src_py/templatey/templates.py
@@ -4,6 +4,7 @@ import functools
 import inspect
 import itertools
 import logging
+import operator
 import sys
 import typing
 from collections import ChainMap
@@ -17,8 +18,12 @@ from collections.abc import Iterator
 from collections.abc import Mapping
 from collections.abc import MutableMapping
 from collections.abc import Sequence
+from contextvars import ContextVar
+from copy import copy
 from dataclasses import _MISSING_TYPE
+from dataclasses import KW_ONLY
 from dataclasses import Field
+from dataclasses import InitVar
 from dataclasses import dataclass
 from dataclasses import field
 from dataclasses import fields
@@ -33,9 +38,11 @@ from typing import ClassVar
 from typing import Literal
 from typing import NamedTuple
 from typing import Protocol
+from typing import Self
 from typing import cast
 from typing import dataclass_transform
 from typing import overload
+from weakref import ref
 
 from docnote import ClcNote
 from typing_extensions import TypeIs
@@ -61,6 +68,11 @@ else:
 TemplateParamsInstance = DataclassInstance
 type TemplateClass = type[TemplateParamsInstance]
 logger = logging.getLogger(__name__)
+# Defining this as a contextvar basically just for testing purposes. We want
+# everything else to get the default global.
+_PENDING_FORWARD_REFS: ContextVar[
+    dict[ForwardRefLookupKey, set[TemplateClass]]] = ContextVar(
+        '_PENDING_FORWARD_REFS', default=defaultdict(set))  # noqa: B039
 
 
 # Technically, these should use the TemplateIntersectable from templates.py,
@@ -221,7 +233,7 @@ if sys.version_info >= (3, 14):
             prerenderer: InterpolationPrerenderer | None = None,
             ) -> Any: ...
 
-# Technically 3.10 or better, but we require that anyways
+# This is technically only valid for >=3.10, but we require that anyways
 else:
     @overload
     def param[_T](
@@ -468,8 +480,8 @@ class TemplateProvenance(tuple[TemplateProvenanceNode]):
 
 
 @dataclass(frozen=True, slots=True)
-class ForwardRefSlotType:
-    """We use this to find all possible ForwardRefSlotType instances
+class ForwardRefLookupKey:
+    """We use this to find all possible ForwardRefLookupKey instances
     for a particular pending template.
 
     Note that, by definition, forward references can only happen in two
@@ -508,10 +520,48 @@ class ForwardRefSlotType:
     scope: FrameType | None
 
 
-# Note that the string annotation here is required because of the forward ref,
-# despite the __future__ import
-class _SlotTreeNode[T: TemplateClass | ForwardRefSlotType](
-        list['_SlotTreeRoute[T]']):
+# Note: the ordering here is to emphasize the fact that the slot
+# name is on the ENCLOSING template, but the slot type is from the
+# NESTED template
+class _SlotTreeRoute[T: _SlotTreeNode](tuple[str, TemplateClass, T]):
+    """An individual route on the slot tree is defined by the attribute
+    name for the slot, the slot type, and the subtree from the slot
+    class.
+
+    These are optimized for the non-union case. Traversing the slot tree
+    with union types will result in a bunch of unnecessary comparisons
+    against slot names of different slot types.
+
+    Note that slot tree routes always have a concrete slot name and slot
+    type, regardless of whether they're in a pending or concrete tree.
+    The reason is simple: in a pending tree, all of the pending classes
+    are dead-end nodes, and define their insertion points using just
+    the string of the slot name, and nothing else.
+    """
+    @classmethod
+    def new(
+            cls,
+            slot_name: str,
+            slot_type: TemplateClass,
+            subtree: T,
+            ) -> _SlotTreeRoute[T]:
+        return cls((slot_name, slot_type, subtree))
+
+    @property
+    def subtree(self) -> T:
+        """This is slower than directly accessing the tuple values, but
+        it makes for clearer code during tree building, where
+        performance isn't quite so critical.
+        """
+        return self[2]
+
+    @property
+    def slot_path(self) -> tuple[str, TemplateClass]:
+        return self[0:2]
+
+
+@dataclass(slots=True)
+class _SlotTreeNode[T: _SlotTreeNode](list[_SlotTreeRoute[T]]):
     """The purpose of the slot tree is to precalculate what sequences of
     getattr() calls we need to traverse to arrive at every instance of a
     particular slot type for a given template, including all nested
@@ -535,32 +585,85 @@ class _SlotTreeNode[T: TemplateClass | ForwardRefSlotType](
     attributes must be searched -- hence using an iteration-optimized
     list instead of a mapping.
     """
-    # We use this to make the logic cleaner when merging trees, but we want
-    # the faster performance of the tuple when actually traversing the tree
-    _routes_by_slot_path: dict[tuple[str, T], _SlotTreeRoute]
+    routes: InitVar[Iterable[_SlotTreeRoute[T]] | None] = None
+
+    _: KW_ONLY
     # We use this to limit the number of entries we need in the transmogrifier
     # lookup during tree merging/copying
-    is_recursive: bool
+    is_recursive: bool = False
     # We use this to differentiate between dissimilar unions, one which
     # continues on to a subtree, and one which ends here with the target
     # instance
-    is_terminus: bool
+    is_terminus: bool = False
 
-    def __init__(
+    # We use this to make the logic cleaner when merging trees, but we want
+    # the faster performance of the tuple when actually traversing the tree
+    _routes_by_slot_path: \
+        dict[tuple[str, TemplateClass], _SlotTreeRoute[T]] = field(init=False)
+
+    def __post_init__(
             self,
-            routes: Iterable[_SlotTreeRoute[T]] | None = None,
-            *,
-            is_recursive: bool = False,
-            is_terminus: bool = False,):
+            routes: Iterable[_SlotTreeRoute[T]] | None):
+        # Explicit instead of super because... idunno, we're breaking things
+        # somehow
         if routes is None:
-            super().__init__()
+            list.__init__(self)
         else:
-            super().__init__(routes)
+            list.__init__(self, routes)
 
-        self.is_recursive = is_recursive
-        self.is_terminus = is_terminus
         self._routes_by_slot_path = {
-            (route[0], route[1]): route for route in self}
+            route.slot_path: route for route in self}
+
+    def empty_clone(self) -> Self:
+        """This creates a clone of the node without any routes. Useful
+        for merging and copying, where you need to do some manual
+        transform of the content.
+
+        Note that this is almost the same as dataclasses.replace, with
+        the exception that we create shallow copies of attributes
+        instead of preserving them.
+        """
+        kwargs = {}
+        for dc_field in fields(self):
+            if dc_field.init:
+                # Note: the copy here is important for any mutable values,
+                # notably the insertion_slot_names.
+                kwargs[dc_field.name] = copy(getattr(self, dc_field.name))
+
+        return type(self)(**kwargs)
+
+    def merge_fields_only(self, other: _SlotTreeNode):
+        """Updates the current node, merging in all non-init field
+        values from other, using |=. Only merges values that exist on
+        the current node, allowing for transformation between pending
+        and concrete node types.
+        """
+        missing = object()
+
+        for dc_field in fields(self):
+            if dc_field.init:
+                current_value = getattr(self, dc_field.name)
+                other_value = getattr(self, dc_field.name, missing)
+
+                if other_value is not missing:
+                    setattr(
+                        self,
+                        dc_field.name,
+                        operator.ior(current_value, other_value))
+
+    @property
+    def requires_transmogrification(self) -> bool:
+        """This determines whether or not copies of the tree require
+        some post-processing to make sure that the tree STRUCTURE is
+        the same. It is used by both copying and merging trees to make
+        sure that the transmogrification lookup is as sparse as
+        possible.
+
+        For the base class, we simply wrap ``is_recursive``, but for
+        the pending tree derived class, we also check other stuff --
+        hence the wrapping.
+        """
+        return self.is_recursive
 
     def append(self, route: _SlotTreeRoute[T]):
         slot_path = (route[0], route[1])
@@ -570,7 +673,7 @@ class _SlotTreeNode[T: TemplateClass | ForwardRefSlotType](
                 + 'name for same slot type! Please search for / report issue '
                 + 'to github along with a traceback.')
 
-        super().append(route)
+        list.append(self, route)
         self._routes_by_slot_path[slot_path] = route
 
     def extend(self, routes: Iterable[_SlotTreeRoute[T]]):
@@ -589,7 +692,7 @@ class _SlotTreeNode[T: TemplateClass | ForwardRefSlotType](
                 + 'name! Please search for / report issue to github along '
                 + 'with a traceback.')
 
-        super().extend(routes)
+        list.extend(self, routes)
         self._routes_by_slot_path.update({
             (route_copy[0], route_copy[1]): route_copy
             for route_copy in routes_copy_2})
@@ -597,48 +700,33 @@ class _SlotTreeNode[T: TemplateClass | ForwardRefSlotType](
     def has_route_for(
             self,
             slot_name: str,
-            slot_type: T
+            slot_type: TemplateClass
             ) -> bool:
         return (slot_name, slot_type) in self._routes_by_slot_path
 
     def get_route_for(
             self,
             slot_name: str,
-            slot_type: T
-            ) -> _SlotTreeRoute:
+            slot_type: TemplateClass
+            ) -> _SlotTreeRoute[T]:
         return self._routes_by_slot_path[(slot_name, slot_type)]
 
 
-class _SlotTreeRoute[T: TemplateClass | ForwardRefSlotType](
-        # Note: the ordering here is to emphasize the fact that the slot
-        # name is on the ENCLOSING template, but the slot type is from the
-        # NESTED template
-        tuple[str, T, _SlotTreeNode]):
-    """An individual route on the slot tree is defined by the attribute
-    name for the slot, the slot type, and the subtree from the slot
-    class.
+type _ConcreteSlotTreeNode = _SlotTreeNode[_ConcreteSlotTreeNode]
 
-    These are optimized for the non-union case. Traversing the slot tree
-    with union types will result in a bunch of unnecessary comparisons
-    against slot names of different slot types.
-    """
 
-    def __new__(
-            cls,
-            slot_name: str,
-            slot_type: T,
-            subtree: _SlotTreeNode,
-            ) -> _SlotTreeRoute:
-        self = super().__new__(cls, (slot_name, slot_type, subtree))
-        return self
+@dataclass(kw_only=True, slots=True)
+class _PendingSlotTreeNode(_SlotTreeNode['_PendingSlotTreeNode']):
+    # Note: the str is the slot_name that the route needs to be inserted under
+    insertion_slot_names: set[str] = field(default_factory=set)
 
     @property
-    def subtree(self) -> _SlotTreeNode:
-        """This is slower than directly accessing the tuple values, but
-        it makes for clearer code during tree building, where
-        performance isn't quite so critical.
-        """
-        return self[2]
+    def is_insertion_point(self) -> bool:
+        return bool(self.insertion_slot_names)
+
+    @property
+    def requires_transmogrification(self) -> bool:
+        return self.is_recursive
 
 
 type TemplateInstanceID = int
@@ -660,31 +748,76 @@ class TemplateSignature:
     Not meant to be created directly; instead, you should use the
     TemplateSignature.new() convenience method.
     """
+    # It's nice to have this available, especially when resolving forward refs,
+    # but unlike eg the slot tree, it's trivially easy for us to avoid GC
+    # loops within the signature
+    template_cls_ref: ref[TemplateClass]
+    _forward_ref_lookup_key: ForwardRefLookupKey
+
     slot_names: frozenset[str]
     var_names: frozenset[str]
     content_names: frozenset[str]
-    # Note that this gets updated when forward references are resolved, so
-    # it's easiest to keep it a set instead of a frozenset
-    included_template_classes: set[TemplateClass]
 
     # Note that these contain all included types, not just the ones on the
     # outermost layer that are associated with the signature. In other words,
     # they include the flattened recursion of all included slots, all the way
     # down the tree
-    _slot_tree_lookup: dict[
-        TemplateClass, _SlotTreeNode[TemplateClass]]
-    _pending_ref_lookup: dict[ForwardRefSlotType, _PendingSlotTree]
+    _slot_tree_lookup: dict[TemplateClass, _ConcreteSlotTreeNode]
+    _pending_ref_lookup: dict[ForwardRefLookupKey, _PendingSlotTreeContainer]
+
+    # I really don't like that we need to remember to recalculate this every
+    # time we update the slot tree lookup, but for rendering performance
+    # reasons we want this to be precalculated before every call to render.
+    included_template_classes: frozenset[TemplateClass] = field(init=False)
+
+    def __post_init__(self):
+        self.refresh_included_template_classes_snapshot()
+        self.refresh_pending_forward_ref_registration()
+
+    def refresh_included_template_classes_snapshot(self):
+        """Call this when resolving forward references to apply any
+        changes made to the slot tree to the template classes snapshot
+        we use for increased render performance.
+        """
+        template_cls = self.template_cls_ref()
+        if template_cls is None:
+            raise RuntimeError(
+                'Template class was garbage collected before template '
+                + 'signature, and then signature asked to refresh included '
+                + 'classes snapshot?!')
+
+        self.included_template_classes = frozenset(
+            {template_cls, *self._slot_tree_lookup})
+
+    def refresh_pending_forward_ref_registration(self):
+        """Call this after having resolved forward references (or when
+        initially constructing the template signature) to register the
+        template class as requiring its forward refs. This is what
+        plumbs up the notification code to actually initiate resolving.
+        """
+        template_cls = self.template_cls_ref()
+        if template_cls is None:
+            raise RuntimeError(
+                'Template class was garbage collected before template '
+                + 'signature, and then signature asked to refresh pending '
+                + 'forward ref registration?!')
+
+        forward_ref_registry = _PENDING_FORWARD_REFS.get()
+        for forward_ref in self._pending_ref_lookup:
+            forward_ref_registry[forward_ref].add(template_cls)
 
     @classmethod
     def new(
             cls,
-            for_cls: type,
+            template_cls: type,
             slots: dict[str,
                 TemplateClass
                 | UnionType
                 | type[ForwardReferenceProxyClass]],
             vars_: dict[str, type | type[ForwardReferenceProxyClass]],
-            content: dict[str, type | type[ForwardReferenceProxyClass]]
+            content: dict[str, type | type[ForwardReferenceProxyClass]],
+            *,
+            forward_ref_lookup_key: ForwardRefLookupKey
             ) -> TemplateSignature:
         """Create a new TemplateSignature based on the gathered slots,
         vars, and content. This does all of the convenience calculations
@@ -699,26 +832,28 @@ class TemplateSignature:
         # words, we want to be able to check a template type, and then see all
         # possible getattr() sequences that arrive at an instance of that
         # template type.
-        tree_wip: dict[TemplateClass, _SlotTreeNode]
+        tree_wip: dict[TemplateClass, _ConcreteSlotTreeNode]
         tree_wip = defaultdict(_SlotTreeNode)
-        pending_ref_lookup: dict[ForwardRefSlotType, _PendingSlotTree] = {}
+        pending_ref_lookup: \
+            dict[ForwardRefLookupKey, _PendingSlotTreeContainer] = {}
         for slot_name, slot_annotation in slots.items():
             cls._extend_wip_slot_and_ref_trees(
-                for_cls,
+                template_cls,
+                forward_ref_lookup_key,
                 slot_name,
                 slot_annotation,
                 slot_tree_lookup=tree_wip,
                 pending_ref_lookup=pending_ref_lookup)
-
         tree_wip.default_factory = None
 
         return cls(
+            _forward_ref_lookup_key=forward_ref_lookup_key,
+            template_cls_ref=ref(template_cls),
             slot_names=slot_names,
             var_names=var_names,
             content_names=content_names,
             _slot_tree_lookup=tree_wip,
-            _pending_ref_lookup=pending_ref_lookup,
-            included_template_classes=set(tree_wip))
+            _pending_ref_lookup=pending_ref_lookup)
 
     @classmethod
     def _extend_wip_slot_and_ref_trees(
@@ -728,15 +863,18 @@ class TemplateSignature:
             # getting the type hints, but instead, the actual class. But we're
             # still in the middle of populating its xable attributes, so we
             # need to short circuit it.
-            for_cls: type,
+            template_cls: type,
+            template_forward_ref_lookup_key: ForwardRefLookupKey,
             slot_name: str,
             slot_annotation:
                 TemplateClass
                 | UnionType
                 | type[ForwardReferenceProxyClass],
             *,
-            slot_tree_lookup: defaultdict[TemplateClass, _SlotTreeNode],
-            pending_ref_lookup: dict[ForwardRefSlotType, _PendingSlotTree]
+            slot_tree_lookup:
+                defaultdict[TemplateClass, _ConcreteSlotTreeNode],
+            pending_ref_lookup:
+                dict[ForwardRefLookupKey, _PendingSlotTreeContainer]
             ) -> None:
         """Builds the slot tree for a single slot on a template class.
 
@@ -756,32 +894,29 @@ class TemplateSignature:
         for slot_type in slot_types:
             if is_forward_reference_proxy(slot_type):
                 forward_ref = slot_type.REFERENCE_TARGET
-                dest_insertion = _SlotTreeNode()
-                dest_slot_route = _SlotTreeRoute(
-                    slot_name,
-                    forward_ref,
-                    dest_insertion)
 
                 existing_pending_tree = pending_ref_lookup.get(forward_ref)
                 if existing_pending_tree is None:
-                    pending_ref_lookup[forward_ref] = _PendingSlotTree(
-                        pending_slot_type=forward_ref,
-                        pending_root_node=_SlotTreeNode([dest_slot_route]),
-                        insertion_nodes=[dest_insertion])
+                    dest_insertion = _PendingSlotTreeNode(
+                        insertion_slot_names={slot_name})
+                    pending_ref_lookup[forward_ref] = (
+                        _PendingSlotTreeContainer(
+                            pending_slot_type=forward_ref,
+                            pending_root_node=dest_insertion))
 
                 else:
-                    existing_pending_tree.pending_root_node.append(
-                        dest_slot_route)
-                    existing_pending_tree.insertion_nodes.append(
-                        dest_insertion)
+                    (
+                        existing_pending_tree
+                        .pending_root_node
+                        .insertion_slot_names.add(slot_name))
 
             # In the simple recursion case -- a template defines a slot of its
             # own class -- we can immediately create a reference loop without
             # needing a forward ref.
-            elif slot_type is for_cls:
+            elif slot_type is template_cls:
                 recursive_slot_tree = slot_tree_lookup[slot_type]
                 recursive_slot_tree.is_recursive = True
-                recursive_slot_route = _SlotTreeRoute(
+                recursive_slot_route = _SlotTreeRoute.new(
                     slot_name,
                     slot_type,
                     recursive_slot_tree)
@@ -791,18 +926,24 @@ class TemplateSignature:
             # guaranteed to be a single concrete ``slot_type``.
             else:
                 cls._extend_wip_slot_and_ref_trees_for_concrete_slot_type(
+                    template_cls,
                     slot_name,
                     slot_type,
+                    template_forward_ref_lookup_key,
                     slot_tree_lookup=slot_tree_lookup,
                     pending_ref_lookup=pending_ref_lookup)
 
     @staticmethod
     def _extend_wip_slot_and_ref_trees_for_concrete_slot_type(
+            template_cls: type,
             slot_name: str,
             slot_type: TemplateClass,
+            encloser_forward_ref_lookup_key: ForwardRefLookupKey,
             *,
-            slot_tree_lookup: defaultdict[TemplateClass, _SlotTreeNode],
-            pending_ref_lookup: dict[ForwardRefSlotType, _PendingSlotTree]
+            slot_tree_lookup:
+                defaultdict[TemplateClass, _ConcreteSlotTreeNode],
+            pending_ref_lookup:
+                dict[ForwardRefLookupKey, _PendingSlotTreeContainer]
             ) -> None:
         """This carves out the slot tree extension for concrete slot
         types into a dedicated helper function to (theoretically) make
@@ -823,7 +964,7 @@ class TemplateSignature:
 
         else:
             enclosing_slot_tree.append(
-                _SlotTreeRoute(
+                _SlotTreeRoute.new(
                     slot_name,
                     slot_type,
                     _SlotTreeNode(is_terminus=True)))
@@ -841,58 +982,71 @@ class TemplateSignature:
             nested_slot_type, nested_slot_tree
         ) in nested_lookup.items():
             _merge_into_slot_tree(
+                slot_type,
                 slot_tree_lookup[nested_slot_type],
-                slot_name,
-                nested_slot_type,
                 nested_slot_tree)
 
         # Okay, now all we have left to do is transform all of the
-        # pending references on the child into pending references on
+        # pending references on the nested template into pending references on
         # the enclosing template.
         for (
-            nested_ref_param, nested_pending_slot_tree
+            nested_forward_ref_key, nested_pending_slot_tree
         ) in nested_pending_refs.items():
+            # Remember that we're in the middle of constructing the signature
+            # for a new template class. If the nested class (from the slot) was
+            # depending on the class we're still constructing, it hasn't yet
+            # been updated with the resovlved class. Therefore, instead of
+            # needing to come back and fix up any recursive forward refs later,
+            # we can simply do them right here, right now.
+            # Also note that we'll NEVER have an existing pending tree for
+            # this, because we're adding it directly and immediately into
+            # the actual slot tree.
+            if nested_forward_ref_key == encloser_forward_ref_lookup_key:
+                _resolve_pending_slot_tree(
+                    nested_pending_slot_tree,
+                    slot_name,
+                    enclosing_cls=template_cls,
+                    enclosing_slot_tree_lookup=slot_tree_lookup,
+                    enclosing_pending_ref_lookup=pending_ref_lookup,
+                    resolved_cls=template_cls,
+                    resolved_slot_tree_lookup=slot_tree_lookup,
+                    resolved_pending_ref_lookup=pending_ref_lookup)
+
+            # Remember that we're simply transforming the existing pending ref
+            # tree from the nested slot into a pending ref tree on the
+            # enclosing slot -- ie, we're not adding any additional insertion
+            # points.
             existing_pending_tree = pending_ref_lookup.get(
-                nested_ref_param)
+                nested_forward_ref_key)
 
             if existing_pending_tree is None:
                 # Transmogrified nodes gives us a lookup from the old
                 # IDs to the new insertion nodes, allowing us to
                 # convert the references to the copy.
-                copied_tree, transmogrified_nodes = _copy_slot_tree(
+                copied_tree = _copy_slot_tree(
                     nested_pending_slot_tree.pending_root_node)
-                transmogrified_insertion_nodes = [
-                    transmogrified_nodes[id(precopy_insertion_node)]
-                    for precopy_insertion_node
-                    in nested_pending_slot_tree.insertion_nodes
-                    if precopy_insertion_node.is_recursive]
-                pending_ref_lookup[nested_ref_param] = (
+                pending_ref_lookup[nested_forward_ref_key] = (
                     # Remember: we already expanded the slot type
                     # from unions!
-                    _PendingSlotTree(
-                        pending_root_node=_SlotTreeNode(
-                            [_SlotTreeRoute(
+                    _PendingSlotTreeContainer(
+                        # Note: the additional tree layer here is because this
+                        # is a slot on the enclosing template -- we need to
+                        # descend a level!
+                        pending_root_node=_PendingSlotTreeNode(
+                            [_SlotTreeRoute.new(
                                 slot_name,
-                                nested_ref_param,
+                                # Note: this is the slot type for the CONCRETE
+                                # class we're currently handling, NOT the
+                                # pending one!
+                                slot_type,
                                 copied_tree)]),
-                        insertion_nodes=transmogrified_insertion_nodes,
-                        pending_slot_type=nested_ref_param)
-                )
+                        pending_slot_type=nested_forward_ref_key))
 
             else:
-                transmogrified_nodes = _merge_into_slot_tree(
-                    existing_pending_tree.pending_root_node,
-                    root_slot_name=slot_name,
-                    to_merge_slot_type=
-                        nested_pending_slot_tree.pending_slot_type,
-                    to_merge=nested_pending_slot_tree.pending_root_node
-                )
-                transmogrified_insertion_nodes = [
-                    transmogrified_nodes[id(precopy_insertion_node)]
-                    for precopy_insertion_node
-                    in nested_pending_slot_tree.insertion_nodes]
-                existing_pending_tree.insertion_nodes.extend(
-                    transmogrified_insertion_nodes)
+                _merge_into_slot_tree(
+                    slot_type,
+                    existing_tree=existing_pending_tree.pending_root_node,
+                    to_merge=nested_pending_slot_tree.pending_root_node)
 
     def extract_function_invocations(
             self,
@@ -930,8 +1084,7 @@ class TemplateSignature:
         # The parallel slot backlog is a stack of stacks. The outer stack
         # corresponds to the depth in the slot tree. The inner stack
         # contains all remaining slots to search for a particular depth.
-        parallel_slot_backlog_stack: list[
-            list[_SlotTreeRoute[TemplateClass]]]
+        parallel_slot_backlog_stack: list[list[_SlotTreeRoute]]
 
         # The goal of the instance backlog stack is to keep track of all the
         # INSTANCES (not slots / attributes!) that are also on the search path,
@@ -954,7 +1107,7 @@ class TemplateSignature:
         # These are all used per-iteration, and don't keep state across
         # iterations.
         nested_slot_name: str
-        nested_slot_routes: list[_SlotTreeRoute]
+        nested_slot_routes: _ConcreteSlotTreeNode
         nested_instances: Sequence[TemplateParamsInstance]
 
         # This is used in multiple loop iterations, plus at the end to add any
@@ -1022,36 +1175,16 @@ class TemplateSignature:
                         current_instance = (
                             instance_backlog_stack[-1][0].instance)
                         nested_instances = getattr(
-                            # Note: the default here is necessary because of
-                            # type unions; we need to support the case where
-                            # the two classes in the union have different
-                            # slot names
-                            current_instance, nested_slot_name, ())
+                            current_instance, nested_slot_name)
                         nested_index = itertools.count()
 
-                        # The parallel path we chose has more steps on the way
-                        # to the leaf node, so we need to continue deeper into
-                        # the tree.
-                        if nested_slot_routes:
-                            nested_provenances = tuple(
-                                TemplateProvenanceNode(
-                                    encloser_slot_key=nested_slot_name,
-                                    encloser_slot_index=next(nested_index),
-                                    instance_id=id(nested_instance),
-                                    instance=nested_instance)
-                                for nested_instance in nested_instances
-                                if isinstance(
-                                    nested_instance, nested_slot_type))
-                            instance_history_stack.append(nested_provenances)
-                            instance_backlog_stack.append(
-                                deque(nested_provenances))
-                            parallel_slot_backlog_stack.append(
-                                list(nested_slot_routes))
-
-                        # The parallel path we chose is actually a leaf node,
+                        # The parallel path we chose is a leaf node,
                         # which means that each nested instance is a
-                        # provenance.
-                        elif nested_slot_routes.is_terminus:
+                        # provenance. Note that, because of recursion loops,
+                        # this can happen whether or not there are nested
+                        # slot routes, so we'll still check for those in just
+                        # a second.
+                        if nested_slot_routes.is_terminus:
                             partial_provenance = tuple(
                                 instance_backlog_level[0]
                                 for instance_backlog_level
@@ -1072,6 +1205,30 @@ class TemplateSignature:
                                 for nested_instance
                                 in nested_instances)
 
+                        # The parallel path we chose has more steps on the way
+                        # to the leaf node, so we need to continue deeper into
+                        # the tree.
+                        if nested_slot_routes:
+                            nested_provenances = tuple(
+                                TemplateProvenanceNode(
+                                    encloser_slot_key=nested_slot_name,
+                                    encloser_slot_index=next(nested_index),
+                                    instance_id=id(nested_instance),
+                                    instance=nested_instance)
+                                for nested_instance in nested_instances
+                                if isinstance(
+                                    nested_instance, nested_slot_type))
+                            instance_history_stack.append(nested_provenances)
+                            instance_backlog_stack.append(
+                                deque(nested_provenances))
+                            parallel_slot_backlog_stack.append(
+                                list(nested_slot_routes))
+
+                        # If there aren't any more nested slot routes, then
+                        # we need to back out one level on the stack.
+                        # Presumably this is also a terminus, but that's
+                        # handled above.
+                        else:
                             # Note that we already popped from the parallel
                             instance_backlog_stack[-1].popleft()
 
@@ -1091,6 +1248,40 @@ class TemplateSignature:
                 template_preload[root_template_class].function_calls.values()
             ))
         return invocations
+
+    def resolve_forward_ref(
+            self,
+            lookup_key: ForwardRefLookupKey,
+            resolved_template_cls: TemplateClass
+            ) -> None:
+        """Notifies a dependent class (one that declared a slot as a
+        forward reference) that the reference is now available, thereby
+        causing it to resolve the forward ref and remove it from its
+        pending trees.
+        """
+        resolved_template_xable = cast(
+            type[TemplateIntersectable], resolved_template_cls)
+        resolved_signature = resolved_template_xable._templatey_signature
+        enclosing_template_cls = self.template_cls_ref()
+
+        if enclosing_template_cls is None:
+            raise RuntimeError(
+                'Template class was garbage collected before template '
+                + 'signature, and then signature asked to resolve forward '
+                + 'ref?!')
+
+        _resolve_pending_slot_tree(
+            pending_tree=self._pending_ref_lookup.pop(lookup_key),
+            slot_name=None,
+            enclosing_cls=enclosing_template_cls,
+            enclosing_slot_tree_lookup=self._slot_tree_lookup,
+            enclosing_pending_ref_lookup=self._pending_ref_lookup,
+            resolved_cls=resolved_template_cls,
+            resolved_slot_tree_lookup=resolved_signature._slot_tree_lookup,
+            resolved_pending_ref_lookup=resolved_signature._pending_ref_lookup)
+
+        self.refresh_included_template_classes_snapshot()
+        self.refresh_pending_forward_ref_registration()
 
 
 def _extract_template_class_locals() -> dict[str, Any] | None:
@@ -1115,7 +1306,7 @@ def _extract_frame_scope() -> FrameType | None:
     are used, we need a way to differentiate between identically-named
     templates within different functions of the same module (or the
     toplevel of the module). We do this by including the frame object
-    on the ForwardRefSlotType whenever we're in a closure. This
+    on the ForwardRefLookupKey whenever we're in a closure. This
     method relies upon ``inspect`` to extract it.
 
     Note that this can be very sensitive to where, exactly, you put it
@@ -1189,7 +1380,7 @@ def _classify_interface_field_flavor(
 
 
 @dataclass(frozen=True, slots=True)
-class _PendingSlotTree:
+class _PendingSlotTreeContainer:
     """Remember that the point here is to eventually build a lookup from
     a ``{type[template]: _SlotTreeNode}``. And we're dealing with
     forward references to the ``type[template]``, meaning we don't have
@@ -1203,13 +1394,12 @@ class _PendingSlotTree:
     all of the insertion nodes, and then store the pending slot tree
     in the slot tree lookup using the resolved template class.
     """
-    pending_slot_type: ForwardRefSlotType
-    pending_root_node: _SlotTreeNode
-    insertion_nodes: list[_SlotTreeNode]
+    pending_slot_type: ForwardRefLookupKey
+    pending_root_node: _PendingSlotTreeNode
 
 
 class ForwardReferenceProxyClass(Protocol):
-    REFERENCE_TARGET: ClassVar[ForwardRefSlotType]
+    REFERENCE_TARGET: ClassVar[ForwardRefLookupKey]
 
 
 def is_forward_reference_proxy(
@@ -1218,10 +1408,10 @@ def is_forward_reference_proxy(
     return isinstance(obj, type) and hasattr(obj, 'REFERENCE_TARGET')
 
 
-def _copy_slot_tree(
-        src_tree: _SlotTreeNode,
-        into_tree: _SlotTreeNode | None = None
-        ) -> tuple[_SlotTreeNode, dict[int, _SlotTreeNode]]:
+def _copy_slot_tree[T: _SlotTreeNode](
+        src_tree: T,
+        into_tree: T | None = None
+        ) -> T:
     """This creates a copy of an existing slot tree. We use it when
     merging nested slot trees into enclosers; otherwise, we end up with
     a huge mess of "it's not clear what object holds which slot tree"
@@ -1236,21 +1426,17 @@ def _copy_slot_tree(
     In both cases, we also return a lookup from
     ``{id(old_node): copied_node}``.
     """
-    copied_tree: _SlotTreeNode
+    copied_tree: T
     if into_tree is None:
-        copied_tree = _SlotTreeNode(
-            is_recursive=src_tree.is_recursive,
-            is_terminus=src_tree.is_terminus)
+        copied_tree = src_tree.empty_clone()
     else:
         copied_tree = into_tree
-        copied_tree.is_recursive |= src_tree.is_recursive
-        copied_tree.is_terminus |= src_tree.is_terminus
+        into_tree.merge_fields_only(src_tree)
 
     # This converts ``id(old_node)`` to the new node instance; it's how we
     # implement copying reference cycles
-    transmogrified_nodes: dict[int, _SlotTreeNode] = {
-        id(src_tree): copied_tree}
-    copy_stack: list[_SlotTreeTraversalFrame] = [_SlotTreeTraversalFrame(
+    transmogrified_nodes: dict[int, T] = {id(src_tree): copied_tree}
+    copy_stack: list[_SlotTreeTraversalFrame[T, T]] = [_SlotTreeTraversalFrame(
         next_subtree_index=0,
         existing_subtree=copied_tree,
         insertion_subtree=src_tree)]
@@ -1264,23 +1450,21 @@ def _copy_slot_tree(
         next_slot_route = current_stack_frame.insertion_subtree[
             current_stack_frame.next_subtree_index]
         next_slot_name, next_slot_type, next_subtree = next_slot_route
+        # Do this ASAP so that we don't accidentally forget it somehow
+        current_stack_frame.next_subtree_index += 1
 
         next_subtree_id = id(next_subtree)
         already_copied_node = transmogrified_nodes.get(next_subtree_id)
         # This could be either the first time we hit a recursive subtree,
         # or a non-recursive subtree.
         if already_copied_node is None:
-            new_subtree = _SlotTreeNode(
-                is_recursive=next_subtree.is_recursive,
-                is_terminus=next_subtree.is_terminus)
+            new_subtree = next_subtree.empty_clone()
 
-            # We only need to do this for recursive subtrees; that's the only
-            # time we need to get a reference back to a previous subtree.
-            if next_subtree.is_recursive:
+            if next_subtree.requires_transmogrification:
                 transmogrified_nodes[next_subtree_id] = new_subtree
 
             current_stack_frame.existing_subtree.append(
-                _SlotTreeRoute(
+                _SlotTreeRoute.new(
                     next_slot_name,
                     next_slot_type,
                     new_subtree,))
@@ -1289,24 +1473,25 @@ def _copy_slot_tree(
                 existing_subtree=new_subtree,
                 insertion_subtree=next_subtree))
 
+        # We've hit a recursive subtree -- one that we've already copied --
+        # which means we don't need to copy it again; instead, we just need to
+        # transmogrify the reference so that the nested route refers back to
+        # the original copied node.
         else:
             current_stack_frame.existing_subtree.append(
-                _SlotTreeRoute(
+                _SlotTreeRoute.new(
                     next_slot_name,
                     next_slot_type,
                     already_copied_node,))
 
-        current_stack_frame.next_subtree_index += 1
-
-    return copied_tree, transmogrified_nodes
+    return copied_tree
 
 
-def _merge_into_slot_tree[T: TemplateClass | ForwardRefSlotType](
-        existing_tree: _SlotTreeNode,
-        root_slot_name: str,
-        to_merge_slot_type: T,
-        to_merge: _SlotTreeNode[T]
-        ) -> dict[int, _SlotTreeNode[T]]:
+def _merge_into_slot_tree[T: _SlotTreeNode](
+        existing_slot_type: TemplateClass,
+        existing_tree: T,
+        to_merge: T
+        ) -> None:
     """This traverses the existing tree, merging in the slot_name and
     its subtrees into the correct locations in the existing slot tree,
     recursively.
@@ -1327,18 +1512,15 @@ def _merge_into_slot_tree[T: TemplateClass | ForwardRefSlotType](
     We return a lookup of ``{id(source_node): dest_node}``, which can
     be used for recording and/or resolving pending forward refs.
     """
-    all_transmogrified_nodes: dict[int, _SlotTreeNode] = {}
+    transmogrified_nodes: dict[int, T] = {id(to_merge): existing_tree}
 
-    # Counterintuitive: since were MERGING trees, the existing_subtree is
+    # Counterintuitive: since we're MERGING trees, the existing_subtree is
     # actually the DESTINATION, and the insertion_subtree the source!
-    merge_stack: list[_SlotTreeTraversalFrame] = [_SlotTreeTraversalFrame(
-        next_subtree_index=0,
-        existing_subtree=existing_tree,
-        insertion_subtree=_SlotTreeNode([
-            _SlotTreeRoute(
-                root_slot_name,
-                to_merge_slot_type,
-                to_merge,)]))]
+    merge_stack: list[_SlotTreeTraversalFrame[T, T]] = [
+        _SlotTreeTraversalFrame(
+            next_subtree_index=0,
+            existing_subtree=existing_tree,
+            insertion_subtree=to_merge)]
     # Yes, in theory, this one specific operation of merging trees would be
     # faster if the trees were dicts instead of iterative structures. But
     # we're not optimizing for tree merging; we're optimizing for rendering!
@@ -1353,52 +1535,312 @@ def _merge_into_slot_tree[T: TemplateClass | ForwardRefSlotType](
         next_slot_route = current_stack_frame.insertion_subtree[
             current_stack_frame.next_subtree_index]
         next_slot_name, next_slot_type, next_subtree = next_slot_route
+        # Do this ASAP so that we don't accidentally forget it somehow (also
+        # because we want to use a continue statement in a second)
+        current_stack_frame.next_subtree_index += 1
 
-        if existing_subtree.has_route_for(next_slot_name, next_slot_type):
+        next_subtree_id = id(next_subtree)
+        already_merged_node = transmogrified_nodes.get(next_subtree_id)
+
+        # For merging, we're going to handle the recursive subtree case first,
+        # because it makes the rest of the logic cleaner
+        if already_merged_node is not None:
+            current_stack_frame.existing_subtree.append(
+                _SlotTreeRoute.new(
+                    next_slot_name, next_slot_type, already_merged_node))
+            continue
+
+        # This accomplishes two things: first, it culls an extra cycle from the
+        # to_merge tree that would ultimately have the same effect. Secondly,
+        # it ensures correct recursion when we're merging in the pending tree
+        # from a class that used us as a forward reference, since the other
+        # class won't yet be resolved.
+        if next_slot_type is existing_slot_type:
+            next_existing_subtree = existing_tree
+            next_existing_subtree.is_recursive = True
+
+            # Remember that next_slot_type is the existing_slot_type that we
+            # started this whole thing off with. Therefore, this should be
+            # impossible: True would imply that we'd already resolved this
+            # recursive branch pointing at itself and are somehow revisiting it
+            # afterwards
+            if existing_subtree.has_route_for(next_slot_name, next_slot_type):
+                raise RecursionError(
+                    'Non-culled infinite recursion while merging templatey '
+                    + 'slot trees!', next_slot_name, next_slot_type)
+
+            else:
+                next_existing_route = _SlotTreeRoute.new(
+                    next_slot_name,
+                    next_slot_type,
+                    next_existing_subtree)
+                existing_subtree.append(next_existing_route)
+
+            # Note that we don't need to update transmogrification for two
+            # reasons: first, because we added the root node at the very
+            # beginning, and second, because we -- by definition -- cannot
+            # have any deeper references to this part of the destination tree,
+            # because  we're culling the depthwise-rest of the source tree
+            continue
+
+        # The existing subtree -- the one we're merging INTO -- has a route for
+        # this slot name and type already, so we need to merge them together
+        # instead of simply copy/transmogrify/cull
+        elif existing_subtree.has_route_for(next_slot_name, next_slot_type):
             next_existing_route = existing_subtree.get_route_for(
                     next_slot_name, next_slot_type)
             __, __, next_existing_subtree = next_existing_route
+            next_existing_subtree.merge_fields_only(next_subtree)
 
-            # We haven't hit a leaf node yet, so we need to keep looking
-            # deeper once we're done.
-            # Note: regardless of leaf or nor, we'll update the terminus/etc
-            # in just a second.
-            if next_subtree:
-                merge_stack.append(_SlotTreeTraversalFrame(
-                    next_subtree_index=0,
-                    existing_subtree=next_existing_subtree,
-                    insertion_subtree=next_subtree))
-
-            next_existing_subtree.is_recursive |= next_subtree.is_recursive
-            next_existing_subtree.is_terminus |= next_subtree.is_terminus
-            if next_existing_subtree.is_recursive:
-                all_transmogrified_nodes[id(next_subtree)] = (
-                    next_existing_subtree)
-
-        # Note: this means there's no existing route for that slot name and
-        # type combo, but there might still be another route for a different
-        # slot type under the same name. It'll be handled on a different
-        # iteration of the merge stack while loop.
+        # The existing subtree doesn't have any existing routes for this, so
+        # we don't need to worry about merging things together -- but we still
+        # need to worry about transmogrification and culling.
+        # Also note that there might be identically-named slots for different
+        # slot types in the case of a union, but that will be handled on a
+        # different iteration of the merge stack while loop.
         else:
-            copied_tree, copied_node_lookup = _copy_slot_tree(next_subtree)
-            current_stack_frame.existing_subtree.append(
-                # Just as a reminder, this is deepening the tree by 1 level
-                _SlotTreeRoute(
-                    next_slot_name,
-                    next_slot_type,
-                    copied_tree,))
-            all_transmogrified_nodes.update(copied_node_lookup)
+            next_existing_subtree = next_subtree.empty_clone()
+            next_existing_route = _SlotTreeRoute.new(
+                next_slot_name,
+                next_slot_type,
+                next_existing_subtree)
+            existing_subtree.append(next_existing_route)
 
+        if next_existing_subtree.requires_transmogrification:
+            transmogrified_nodes[next_subtree_id] = next_existing_subtree
+
+        if next_subtree:
+            merge_stack.append(_SlotTreeTraversalFrame(
+                next_subtree_index=0,
+                existing_subtree=next_existing_subtree,
+                insertion_subtree=next_subtree))
+
+
+def _resolve_pending_slot_tree(  # noqa: PLR0913
+        pending_tree: _PendingSlotTreeContainer,
+        slot_name: str | None,
+        enclosing_cls: TemplateClass,
+        enclosing_slot_tree_lookup: dict[TemplateClass, _ConcreteSlotTreeNode],
+        enclosing_pending_ref_lookup:
+            dict[ForwardRefLookupKey, _PendingSlotTreeContainer],
+        resolved_cls: TemplateClass,
+        resolved_slot_tree_lookup: dict[TemplateClass, _ConcreteSlotTreeNode],
+        resolved_pending_ref_lookup:
+            dict[ForwardRefLookupKey, _PendingSlotTreeContainer],
+        ) -> None:
+    """Once a forward ref has been resolved, it needs to have both the
+    concrete and pending trees from the now-resolved class merged into
+    the respective trees of the enclosing class.
+
+    There are several things to be mindful of here:
+    ++  Pending trees are really factories for concrete slot trees. Each
+        nested template class in the resolved class will be inserted
+        at the pending tree insertion point. In other words, if there
+        are N insertion points, and the resolved class has M slots, then
+        N * M concretified slot trees will need to be merged into the
+        enclosing class.
+    ++  The slot tree of the resolved class (or its pending tree) may
+        include references to the enclosing class. These subtrees need
+        to then be short-circuited, and replaced by references to the
+        slot tree root for the enclosing class.
+    ++  The resolved class may not be completely finalized yet, since
+        we are also called during initial tree creation for the resolved
+        class (though only when recursive loops are encountered).
+        Therefore, we need to explicitly pass the concrete and pending
+        slot tree lookups for each of the enclosing and resolved
+        classes, in addition to the class itself
+    ++  The resolved and enclosing classes might be the same class (as
+        in the above case, where this is called during initial tree
+        creation for a resolved class in a recursive loop).
+    """
+    # We need to make sure to include the actual resolved class itself in
+    # the slot tree! But instead of special-casing it, we can just let it be
+    # handled by the same logic for the nested ones.
+    resolved_slot_item = (resolved_cls, _SlotTreeNode(is_terminus=True))
+    all_nested_slot_items = itertools.chain(
+        resolved_slot_tree_lookup.items(),
+        [resolved_slot_item])
+
+    pending_tree_root_node = pending_tree.pending_root_node
+    for nested_template_cls,  nested_root_node in all_nested_slot_items:
+        # Note: this means that we're resolving against the root tree. That
+        # means that the pending tree is relative to it, and not to a nested
+        # slot. This implies that we're resolving a forward ref on an
+        # already-existing template class.
+        if slot_name is None:
+            tree_after_insertions = _apply_insertions(
+                resolved_cls,
+                pending_tree_root_node,
+                nested_root_node)
+
+        # However, in this case, we're resolving against a specific slot on
+        # a root key. This implies that we're resolving a forward ref on a
+        # not-yet-exited-the-decorator template class.
+        else:
+            # Note that the nesting is crucial; that's what puts the tree under
+            # the correct slot for the enclosing class, instead of retaining
+            # the tree depth and root slot from the resolved class.
+            tree_after_insertions = _SlotTreeNode([_SlotTreeRoute.new(
+                slot_name,
+                resolved_cls,
+                _apply_insertions(
+                    resolved_cls,
+                    pending_tree_root_node,
+                    nested_root_node))])
+
+        dest_tree = enclosing_slot_tree_lookup.get(nested_template_cls)
+        # Note that we still need to call merge_into to perform any needed
+        # culling, so we can't simply assign the dest_tree as the value in the
+        # enclosing lookup
+        if dest_tree is None:
+            dest_tree = enclosing_slot_tree_lookup[nested_template_cls] = (
+                _SlotTreeNode())
+
+        _merge_into_slot_tree(
+            enclosing_cls,
+            dest_tree,
+            tree_after_insertions)
+
+    for (
+        forward_ref_key,
+        pending_tree_container
+    ) in resolved_pending_ref_lookup.items():
+        # Note: this means that we're resolving against the root tree. That
+        # means that the pending tree is relative to it, and not to a nested
+        # slot. This implies that we're resolving a forward ref on an
+        # already-existing template class.
+        if slot_name is None:
+            tree_after_insertions = _apply_insertions(
+                resolved_cls,
+                pending_tree_root_node,
+                pending_tree_container.pending_root_node)
+
+        # However, in this case, we're resolving against a specific slot on
+        # a root key. This implies that we're resolving a forward ref on a
+        # not-yet-exited-the-decorator template class.
+        else:
+            # Again, nesting here is crucial, otherwise the tree would be
+            # missing its slot name for the enclosing_cls
+            tree_after_insertions = _PendingSlotTreeNode([_SlotTreeRoute.new(
+                slot_name,
+                resolved_cls,
+                _apply_insertions(
+                    resolved_cls,
+                    pending_tree_root_node,
+                    pending_tree_container.pending_root_node))])
+
+        dest_pending = enclosing_pending_ref_lookup.get(forward_ref_key)
+        # Note that we still need to call merge_into to perform any needed
+        # culling, so we can't simply assign the dest_tree as the value in the
+        # enclosing lookup
+        if dest_pending is None:
+            dest_tree =  _PendingSlotTreeNode()
+            enclosing_pending_ref_lookup[forward_ref_key] = (
+                _PendingSlotTreeContainer(forward_ref_key, dest_tree))
+        else:
+            dest_tree = dest_pending.pending_root_node
+
+        _merge_into_slot_tree(
+            enclosing_cls,
+            dest_tree,
+            tree_after_insertions)
+
+
+def _apply_insertions[T: _ConcreteSlotTreeNode | _PendingSlotTreeNode](
+        resolved_cls: TemplateClass,
+        pending_tree: _PendingSlotTreeNode,
+        nested_root_node: T,
+        ) -> T:
+    """For a particular pending tree and a single nested CONCRETE root
+    node, this searches the pending tree for all insertion points and
+    then inserts the concrete root node at that point.
+
+    **Note that this does not cull any superfluous recursive
+    refererence cycles.** You still need to merge the resulting tree
+    into the actual slot tree lookup, and then that does the culling.
+    """
+    resulting_tree: T = type(nested_root_node)()
+    resulting_tree.merge_fields_only(pending_tree)
+    # This converts ``id(old_node)`` to the new node instance; it's how we
+    # implement copying reference cycles
+    transmogrified_nodes: dict[int, _SlotTreeNode] = {
+        id(pending_tree): resulting_tree}
+
+    stack: \
+        list[_SlotTreeTraversalFrame[_SlotTreeNode, _PendingSlotTreeNode]] = [
+        _SlotTreeTraversalFrame(
+            next_subtree_index=0,
+            existing_subtree=resulting_tree,
+            insertion_subtree=pending_tree)]
+
+    while stack:
+        current_stack_frame = stack[-1]
+        if current_stack_frame.exhausted:
+            stack.pop()
+            continue
+
+        src_subtree = current_stack_frame.insertion_subtree
+        target_subtree = current_stack_frame.existing_subtree
+        next_slot_route = src_subtree[current_stack_frame.next_subtree_index]
+        next_slot_name, next_slot_type, next_subtree = next_slot_route
+        # Do this ASAP so that we don't accidentally forget it somehow
         current_stack_frame.next_subtree_index += 1
 
-    return all_transmogrified_nodes
+        # Note that this will still get merged into the actual full slot tree
+        # for the enclosing template, which will cull any extra links in
+        # recursive reference cycles, so we don't need to worry about that
+        # here.
+        next_subtree_id = id(next_subtree)
+        already_applied_node = transmogrified_nodes.get(next_subtree_id)
+
+        # This could be either the first time we hit a recursive subtree,
+        # or a non-recursive subtree.
+        if already_applied_node is None:
+            new_subtree = _SlotTreeNode()
+            new_subtree.merge_fields_only(next_subtree)
+
+            if next_subtree.requires_transmogrification:
+                transmogrified_nodes[next_subtree_id] = new_subtree
+
+            target_subtree.append(
+                _SlotTreeRoute.new(
+                    next_slot_name,
+                    next_slot_type,
+                    new_subtree))
+            stack.append(_SlotTreeTraversalFrame(
+                next_subtree_index=0,
+                existing_subtree=new_subtree,
+                insertion_subtree=next_subtree))
+
+        # We've hit a recursive subtree -- one that we've already copied --
+        # which means we don't need to copy it again; instead, we just need to
+        # transmogrify the reference so that the nested route refers back to
+        # the original copied node.
+        else:
+            # Note: is_recursive was already set!
+            target_subtree.append(
+                _SlotTreeRoute.new(
+                    next_slot_name,
+                    next_slot_type,
+                    already_applied_node))
+
+        # Note that this is IN ADDITION to copying any nested routes! This is
+        # purely for the insertions.
+        for insertion_slot_name in src_subtree.insertion_slot_names:
+            target_subtree.append(
+                _SlotTreeRoute.new(
+                    insertion_slot_name,
+                    resolved_cls,
+                    _copy_slot_tree(nested_root_node)))
+
+    return resulting_tree
 
 
 @dataclass(slots=True)
-class _SlotTreeTraversalFrame:
+class _SlotTreeTraversalFrame[ET: _SlotTreeNode, IT: _SlotTreeNode]:
     next_subtree_index: int
-    existing_subtree: _SlotTreeNode
-    insertion_subtree: _SlotTreeNode
+    existing_subtree: ET
+    insertion_subtree: IT
 
     @property
     def exhausted(self) -> bool:
@@ -1411,13 +1853,13 @@ class _SlotTreeTraversalFrame:
 # Note: mutablemapping because otherwise chainmap complains. Even though they
 # aren't actually implemented, this is a quick way of getting typing to work
 @dataclass(kw_only=True, slots=True)
-class _TypehintForwardrefLookup(MutableMapping[str, type]):
+class _ForwardRefGeneratingNamespaceLookup(MutableMapping[str, type]):
     template_module: str
     template_scope: FrameType | None
-    captured_refs: set[ForwardRefSlotType] = field(default_factory=set)
+    captured_refs: set[ForwardRefLookupKey] = field(default_factory=set)
 
     def __getitem__(self, key: str) -> type:
-        forward_ref = ForwardRefSlotType(
+        forward_ref = ForwardRefLookupKey(
             module=self.template_module,
             name=key,
             scope=self.template_scope)
@@ -1433,17 +1875,25 @@ class _TypehintForwardrefLookup(MutableMapping[str, type]):
         self.captured_refs.add(forward_ref)
         return ForwardReferenceProxyClass
 
+    # Required for mutable mapping protocol, but not for the namespace lookup.
     def __iter__(self) -> Iterator[str]:
-        raise NotImplementedError
+        raise TypeError(
+            'Unsupported method call in templatey foward ref implementation.')
 
+    # Required for mutable mapping protocol, but not for the namespace lookup.
     def __len__(self) -> int:
-        raise NotImplementedError
+        raise TypeError(
+            'Unsupported method call in templatey foward ref implementation.')
 
+    # Required for mutable mapping protocol, but not for the namespace lookup.
     def __setitem__(self, key, value) -> None:
-        raise NotImplementedError
+        raise TypeError(
+            'Unsupported method call in templatey foward ref implementation.')
 
+    # Required for mutable mapping protocol, but not for the namespace lookup.
     def __delitem__(self, key) -> None:
-        raise NotImplementedError
+        raise TypeError(
+            'Unsupported method call in templatey foward ref implementation.')
 
 
 @dataclass_transform(field_specifiers=(param, field, Field))
@@ -1464,6 +1914,13 @@ def make_template_definition[T: type](
     cls._templatey_config = template_config
     cls._templatey_resource_locator = template_resource_locator
 
+    template_module = cls.__module__
+    template_scope = _extract_frame_scope()
+    template_forward_ref = ForwardRefLookupKey(
+        module=template_module,
+        name=cls.__name__,
+        scope=template_scope)
+
     # We're prioritizing the typical case here, where the templates are defined
     # at the module toplevel, and therefore accessible within the module
     # globals. However, if the template is defined within a closure, we might
@@ -1481,7 +1938,7 @@ def make_template_definition[T: type](
             ++  the type hint is a forward reference.
 
             In both cases, we'll wrap the request into a
-            ``ForwardRefSlotType``, which will then hopefully be
+            ``ForwardRefLookupKey``, which will then hopefully be
             resolved as soon as the forward reference is declared.
             If it's never resolved, however, we will raise whenever
             ``render`` is called.
@@ -1495,10 +1952,9 @@ def make_template_definition[T: type](
         # we need to recover the existing check for the actual globals, since
         # otherwise **all** global names would be overwritten by the forward
         # reference.
-        template_module = cls.__module__
-        forwardref_lookup = _TypehintForwardrefLookup(
+        forwardref_lookup = _ForwardRefGeneratingNamespaceLookup(
             template_module=template_module,
-            template_scope=_extract_frame_scope())
+            template_scope=template_scope)
         # This is the same as the current implementation of get_type_hints
         # in cpython for classes:
         # https://github.com/python/cpython/blob/0045100ccbc3919e8990fa59bc413fe38d21b075/Lib/typing.py#L2325
@@ -1560,42 +2016,45 @@ def make_template_definition[T: type](
                 'templatey.prerenderer')
 
     cls._templatey_signature = TemplateSignature.new(
-        for_cls=cls,
+        template_cls=cls,
         slots=slots,
         vars_=vars_,
-        content=content)
+        content=content,
+        forward_ref_lookup_key=template_forward_ref)
     converter_cls = namedtuple('TemplateyConverters', tuple(prerenderers))
     cls._templatey_prerenderers = converter_cls(**prerenderers)
+
+    # Note: this needs to be the absolute last thing, because we need to fully
+    # satisfy the intersectable interface before we can call it.
     _resolve_forward_references(cls)
     return cls
 
 
-def _resolve_forward_references(
-        pending_template_cls: type[TemplateIntersectable]):
+def _resolve_forward_references(pending_template_cls: TemplateClass):
     """The very last thing to do before we return the class after
     template decoration is to resolve all forward references inside the
     class. To do that, we first need to construct the corresponding
-    ForwardRefSlotType and check for it in the pending forward refs
+    ForwardRefLookupKey and check for it in the pending forward refs
     lookup.
 
     If we find one, we then need to update the values there, while
     checking for and correctly handling recursion.
     """
-    lookup_key = ForwardRefSlotType(
+    lookup_key = ForwardRefLookupKey(
         module=pending_template_cls.__module__,
         name=pending_template_cls.__name__,
         scope=_extract_frame_scope())
-    print(lookup_key)
-    # raise NotImplementedError(
-    #     '''
-        
-        
-    #     TODO LEFT OFF HERE
-        
-    #     otherwise, basically, you just need to finish what's described
-    #     in the docstring.
-        
-    #     ''')
+
+    forward_ref_registry = _PENDING_FORWARD_REFS.get()
+    dependent_template_classes = forward_ref_registry.get(lookup_key)
+    if dependent_template_classes is not None:
+        for dependent_template_cls in dependent_template_classes:
+            dependent_xable = cast(
+                TemplateIntersectable, dependent_template_cls)
+            dependent_xable._templatey_signature.resolve_forward_ref(
+                lookup_key, pending_template_cls)
+
+        del forward_ref_registry[lookup_key]
 
 
 @dataclass(frozen=True, slots=True)

--- a/src_py/templatey/templates.py
+++ b/src_py/templatey/templates.py
@@ -6,21 +6,26 @@ import itertools
 import logging
 import sys
 import typing
+from collections import ChainMap
 from collections import defaultdict
 from collections import deque
 from collections import namedtuple
 from collections.abc import Callable
 from collections.abc import Collection
 from collections.abc import Iterable
+from collections.abc import Iterator
 from collections.abc import Mapping
+from collections.abc import MutableMapping
 from collections.abc import Sequence
 from dataclasses import _MISSING_TYPE
 from dataclasses import Field
 from dataclasses import dataclass
 from dataclasses import field
 from dataclasses import fields
+from itertools import tee as tee_iterable
 from textwrap import dedent
 from types import EllipsisType
+from types import FrameType
 from types import UnionType
 from typing import Annotated
 from typing import Any
@@ -32,12 +37,8 @@ from typing import cast
 from typing import dataclass_transform
 from typing import overload
 
-try:
-    from typing import TypeIs  # type: ignore
-except ImportError:
-    from typing_extensions import TypeIs
-
 from docnote import ClcNote
+from typing_extensions import TypeIs
 
 from templatey._annotations import InterfaceAnnotation
 from templatey._annotations import InterfaceAnnotationFlavor
@@ -463,8 +464,138 @@ class TemplateProvenance(tuple[TemplateProvenanceNode]):
         return value
 
 
-type _SlotTreeNode = tuple[_SlotTreeRoute, ...]
-type _SlotTreeRoute = tuple[str, _SlotTreeNode]
+# Note that the string annotation here is required because of the forward ref,
+# despite the __future__ import
+class _SlotTreeNode(list['_SlotTreeRoute']):
+    """The purpose of the slot tree is to precalculate what sequences of
+    getattr() calls we need to traverse to arrive at every instance of a
+    particular slot type for a given template, including all nested
+    templates.
+
+    **These are optimized for rendering, not for template declaration.**
+
+    The reason this is useful is for batching during rendering. This is
+    important for function calls: it allows us to pre-execute all env
+    func calls for a template before we start rendering it. In the
+    future, it will also serve the same role for discovering the actual
+    template types for dynamic slots, allowing us to load the needed
+    template types in advance.
+
+    An individual node on the slot tree is a list of all possible
+    attribute names (as ``_SlotTreeRoute``s) that a particular search
+    pass needs to check for a given instance. Note that **all** of the
+    attributes must be searched -- hence using an iteration-optimized
+    list instead of a mapping.
+    """
+    # We use this to make the logic cleaner when merging trees, but we want
+    # the faster performance of the tuple when actually traversing the tree
+    _routes_by_slot_name: dict[str, _SlotTreeRoute]
+    # We use this to limit the number of entries we need in the transmogrifier
+    # lookup during tree merging/copying
+    is_recursive: bool
+    # We use this to differentiate between dissimilar unions, one which
+    # continues on to a subtree, and one which ends here with the target
+    # instance
+    is_terminus: bool
+
+    def __new__(
+            cls,
+            routes: Iterable[_SlotTreeRoute] | None = None,
+            *,
+            is_recursive: bool = False,
+            is_terminus: bool = False,
+            ) -> _SlotTreeNode:
+        if routes is None:
+            self = super().__new__(cls)
+        else:
+            self = super().__new__(cls, routes)
+
+        self.is_recursive = is_recursive
+        self.is_terminus = is_terminus
+        self._routes_by_slot_name = {route[0]: route for route in self}
+        return self
+
+    def append(self, route: _SlotTreeRoute):
+        slot_name = route[0]
+        if slot_name in self._routes_by_slot_name:
+            raise ValueError(
+                'Templatey internal error: attempt to append duplicate slot '
+                + 'name! Please search for / report issue to github along '
+                + 'with a traceback.')
+
+        super().append(route)
+        self._routes_by_slot_name[slot_name] = route
+
+    def extend(self, routes: Iterable[_SlotTreeRoute]):
+        routes, routes_copy_1, routes_copy_2 = tee_iterable(routes, 3)
+
+        if any(
+            route_copy[0] in self._routes_by_slot_name
+            for route_copy in routes_copy_1
+        ):
+            raise ValueError(
+                'Templatey internal error: attempt to append duplicate slot '
+                + 'name! Please search for / report issue to github along '
+                + 'with a traceback.')
+
+        super().extend(routes)
+        self._routes_by_slot_name.update({
+            route_copy[0]: route_copy for route_copy in routes_copy_2})
+
+    def has_route_for(self, slot_name: str) -> bool:
+        return slot_name in self._routes_by_slot_name
+
+    def get_route_for(self, slot_name: str) -> _SlotTreeRoute:
+        return self._routes_by_slot_name[slot_name]
+
+
+class _SlotTreeRoute(tuple[str, _SlotTreeNode]):
+    """An individual route on the slot tree is defined by the attribute
+    name for the slot, and the subtree from the slot class.
+
+    TODO: add an explicit terminus to support partially-dissimilar
+    unions.
+    """
+    # We use this to detect recursion loops when merging trees.
+    # Note: each route is a different slot, and therefore usually also a
+    # different slot class, but it might be a union, which we convert into
+    # a set.
+    slot_types: set[type[TemplateParamsInstance] | ForwardReferenceParam]
+
+    def __new__(
+            cls,
+            slot_name: str,
+            subtree: _SlotTreeNode,
+            *,
+            slot_types:
+                set[type[TemplateParamsInstance] | ForwardReferenceParam]
+            ) -> _SlotTreeRoute:
+        self = super().__new__(cls, (slot_name, subtree))
+        self.slot_types = slot_types
+
+        return self
+
+    @classmethod
+    def from_slot_type(
+            cls,
+            slot_name: str,
+            subtree: _SlotTreeNode,
+            *,
+            # Note: Unions automatically get converted into a set.
+            slot_type:
+                type[TemplateParamsInstance]
+                | ForwardReferenceParam
+                | UnionType,
+            ) -> _SlotTreeRoute:
+
+        if isinstance(slot_type, UnionType):
+            slot_types = set(slot_type.__args__)
+        else:
+            slot_types = {slot_type}
+
+        return cls(slot_name, subtree, slot_types=slot_types)
+
+
 type TemplateInstanceID = int
 type GroupedTemplateInvocations = dict[TemplateClass, list[TemplateProvenance]]
 type TemplateLookupByID = dict[TemplateInstanceID, TemplateParamsInstance]
@@ -484,24 +615,30 @@ class TemplateSignature:
     Not meant to be created directly; instead, you should use the
     TemplateSignature.new() convenience method.
     """
-    slots: Mapping[str, type[TemplateParamsInstance] | UnionType]
     slot_names: frozenset[str]
-    vars_: dict[str, type]
     var_names: frozenset[str]
-    content: dict[str, type]
     content_names: frozenset[str]
-    included_template_classes: frozenset[type[TemplateParamsInstance]]
+    # Note that this gets updated when forward references are resolved, so
+    # it's easiest to keep it a set instead of a frozenset
+    included_template_classes: set[type[TemplateParamsInstance]]
 
-    # Note that this contains all included types, not just the ones on the
-    # outermost layer that are associated with the signature
+    # Note that these contain all included types, not just the ones on the
+    # outermost layer that are associated with the signature. In other words,
+    # they include the flattened recursion of all included slots, all the way
+    # down the tree
     _slot_tree_lookup: dict[type[TemplateParamsInstance], _SlotTreeNode]
+    _pending_ref_lookup: dict[ForwardReferenceParam, _PendingSlotTree]
 
     @classmethod
     def new(
             cls,
-            slots: dict[str, type[TemplateParamsInstance] | UnionType],
-            vars_: dict[str, type],
-            content: dict[str, type]
+            for_cls: type,
+            slots: dict[str,
+                type[TemplateParamsInstance]
+                | UnionType
+                | type[ForwardReferenceProxyClass]],
+            vars_: dict[str, type | type[ForwardReferenceProxyClass]],
+            content: dict[str, type | type[ForwardReferenceProxyClass]]
             ) -> TemplateSignature:
         """Create a new TemplateSignature based on the gathered slots,
         vars, and content. This does all of the convenience calculations
@@ -511,44 +648,176 @@ class TemplateSignature:
         var_names = frozenset(vars_)
         content_names = frozenset(content)
 
-        slot_tree_lookup = {}
-        tree_wip: dict[type[TemplateParamsInstance], list[_SlotTreeRoute]]
-        tree_wip = defaultdict(list)
-        for parent_slot_name, parent_slot_annotation in slots.items():
-            parent_slot_types: Collection[type[TemplateParamsInstance]]
-            if isinstance(parent_slot_annotation, UnionType):
-                parent_slot_types = parent_slot_annotation.__args__
+        # Quick refresher: our goal here is to construct a lookup that gets
+        # us a route to every instance of a particular template type. In other
+        # words, we want to be able to check a template type, and then see all
+        # possible getattr() sequences that arrive at an instance of that
+        # template type.
+        tree_wip: dict[type[TemplateParamsInstance], _SlotTreeNode]
+        tree_wip = defaultdict(_SlotTreeNode)
+        pending_ref_lookup: dict[ForwardReferenceParam, _PendingSlotTree] = {}
+        for slot_name, slot_annotation in slots.items():
+            cls._extend_wip_slot_and_ref_trees(
+                for_cls,
+                slot_name,
+                slot_annotation,
+                slot_tree_lookup=tree_wip,
+                pending_ref_lookup=pending_ref_lookup)
+
+        tree_wip.default_factory = None
+
+        return cls(
+            slot_names=slot_names,
+            var_names=var_names,
+            content_names=content_names,
+            _slot_tree_lookup=tree_wip,
+            _pending_ref_lookup=pending_ref_lookup,
+            included_template_classes=set(tree_wip))
+
+    @staticmethod
+    def _extend_wip_slot_and_ref_trees(
+            # This is used as a recursion guard. If we have a simple recursion,
+            # there (somewhat surprisingly) isn't a forward ref at all when
+            # getting the type hints, but instead, the actual class. But we're
+            # still in the middle of populating its xable attributes, so we
+            # need to short circuit it.
+            for_cls: type,
+            slot_name: str,
+            slot_annotation:
+                type[TemplateParamsInstance]
+                | UnionType
+                | type[ForwardReferenceProxyClass],
+            *,
+            slot_tree_lookup: defaultdict[
+                type[TemplateParamsInstance], _SlotTreeNode],
+            pending_ref_lookup: dict[ForwardReferenceParam, _PendingSlotTree]
+            ) -> None:
+        """Builds the slot tree for a single slot on a template class.
+        Returns a tuple of (fully resolved, pending forward reference)
+        lookups.
+
+        Keep in mind that child slots might themselves include pending
+        trees, so we can't infer based on the annotation type whether
+        or not the result will include them or not.
+        """
+        slot_types: Collection[
+            type[TemplateParamsInstance]
+            | type[ForwardReferenceProxyClass]]
+
+        if isinstance(slot_annotation, UnionType):
+            slot_types = slot_annotation.__args__
+        else:
+            slot_types = (slot_annotation,)
+
+        for slot_type in slot_types:
+            if is_forward_reference_proxy(slot_type):
+                forward_ref = slot_type.REFERENCE_TARGET
+                dest_insertion = _SlotTreeNode()
+                dest_slot_route = _SlotTreeRoute.from_slot_type(
+                    slot_name,
+                    dest_insertion,
+                    slot_type=forward_ref)
+
+                existing_pending_tree = pending_ref_lookup.get(forward_ref)
+                if existing_pending_tree is None:
+                    pending_ref_lookup[forward_ref] = _PendingSlotTree(
+                        pending_slot_type=forward_ref,
+                        pending_root_node=_SlotTreeNode([dest_slot_route]),
+                        insertion_nodes=[dest_insertion])
+
+                else:
+                    existing_pending_tree.pending_root_node.append(
+                        dest_slot_route)
+                    existing_pending_tree.insertion_nodes.append(
+                        dest_insertion)
+
+            # In the simple recursion case -- a template defines a slot of its
+            # own class -- we can immediately create a reference loop without
+            # needing a forward ref.
+            elif slot_type is for_cls:
+                recursive_slot_tree = slot_tree_lookup[slot_type]
+                recursive_slot_tree.is_recursive = True
+                recursive_slot_route = _SlotTreeRoute.from_slot_type(
+                    slot_name,
+                    recursive_slot_tree,
+                    slot_type=slot_type)
+                recursive_slot_tree.append(recursive_slot_route)
+
             else:
-                parent_slot_types = (parent_slot_annotation,)
-
-            for parent_slot_type in parent_slot_types:
                 slot_xable = cast(
-                    type[TemplateIntersectable], parent_slot_type)
-                child_lookup = (
+                    type[TemplateIntersectable], slot_type)
+                nested_lookup = (
                     slot_xable._templatey_signature._slot_tree_lookup)
-                for child_slot_type, child_slot_tree in child_lookup.items():
-                    tree_wip[child_slot_type].append(
-                        (parent_slot_name, child_slot_tree))
+                nested_pending_refs = (
+                    slot_xable._templatey_signature._pending_ref_lookup)
 
-                # Note that the empty tuple here denotes that it doesn't have
+                # Note that because of the nested for loop, this will put all
+                # possible slots from the entire union on equal footing.
+                for (
+                    nested_slot_type, nested_slot_tree
+                ) in nested_lookup.items():
+                    _merge_into_slot_tree(
+                        slot_tree_lookup[nested_slot_type],
+                        slot_name,
+                        nested_slot_type,
+                        nested_slot_tree)
+
+                # Okay, now all we have left to do is transform all of the
+                # pending references on the child into pending references on
+                # the enclosing template.
+                for (
+                    nested_ref_param, nested_pending_slot_tree
+                ) in nested_pending_refs.items():
+                    existing_pending_tree = pending_ref_lookup.get(
+                        nested_ref_param)
+
+                    if existing_pending_tree is None:
+                        # Transmogrified nodes gives us a lookup from the old
+                        # IDs to the new insertion nodes, allowing us to
+                        # convert the references to the copy.
+                        copied_tree, transmogrified_nodes = _copy_slot_tree(
+                            nested_pending_slot_tree.pending_root_node)
+                        transmogrified_insertion_nodes = [
+                            transmogrified_nodes[id(precopy_insertion_node)]
+                            for precopy_insertion_node
+                            in nested_pending_slot_tree.insertion_nodes
+                            if precopy_insertion_node.is_recursive]
+                        pending_ref_lookup[nested_ref_param] = (
+                            _PendingSlotTree(
+                                pending_root_node=_SlotTreeNode(
+                                    [_SlotTreeRoute.from_slot_type(
+                                        slot_name,
+                                        copied_tree,
+                                        slot_type=nested_ref_param)]),
+                                insertion_nodes=transmogrified_insertion_nodes,
+                                pending_slot_type=nested_ref_param)
+                        )
+
+                    else:
+                        transmogrified_nodes = _merge_into_slot_tree(
+                            existing_pending_tree.pending_root_node,
+                            root_slot_name=slot_name,
+                            to_merge_slot_type=
+                                nested_pending_slot_tree.pending_slot_type,
+                            to_merge=nested_pending_slot_tree.pending_root_node
+                        )
+                        transmogrified_insertion_nodes = [
+                            transmogrified_nodes[id(precopy_insertion_node)]
+                            for precopy_insertion_node
+                            in nested_pending_slot_tree.insertion_nodes]
+                        existing_pending_tree.insertion_nodes.extend(
+                            transmogrified_insertion_nodes)
+
+                # Note that the empty node here denotes that it doesn't have
                 # any children **for the current node.** That doesn't mean that
                 # the child tree doesn't have any other slots of the same type
                 # (hence using append), but we're mapping ALL of the nodes, and
                 # NOT just the leaves.
-                tree_wip[parent_slot_type].append((parent_slot_name, ()))
-
-        for slot_key, route_list in tree_wip.items():
-            slot_tree_lookup[slot_key] = tuple(route_list)
-
-        return cls(
-            slots=slots,
-            slot_names=slot_names,
-            vars_=vars_,
-            var_names=var_names,
-            content=content,
-            content_names=content_names,
-            _slot_tree_lookup=slot_tree_lookup,
-            included_template_classes=frozenset(slot_tree_lookup))
+                slot_tree_lookup[slot_type].append(
+                    _SlotTreeRoute.from_slot_type(
+                        slot_name,
+                        _SlotTreeNode(is_terminus=True),
+                        slot_type=slot_type))
 
     def extract_function_invocations(
             self,
@@ -609,7 +878,7 @@ class TemplateSignature:
         # These are all used per-iteration, and don't keep state across
         # iterations.
         child_slot_name: str
-        child_slot_routes: tuple[_SlotTreeRoute, ...]
+        child_slot_routes: list[_SlotTreeRoute]
         child_instances: Sequence[TemplateParamsInstance]
 
         # This is used in multiple loop iterations, plus at the end to add any
@@ -673,7 +942,11 @@ class TemplateSignature:
                         current_instance = (
                             instance_backlog_stack[-1][0].instance)
                         child_instances = getattr(
-                            current_instance, child_slot_name)
+                            # Note: the default here is necessary because of
+                            # type unions; we need to support the case where
+                            # the two classes in the union have different
+                            # slot names
+                            current_instance, child_slot_name, ())
                         child_index = itertools.count()
 
                         # The parallel path we chose has more steps on the way
@@ -737,6 +1010,433 @@ class TemplateSignature:
         return invocations
 
 
+def _extract_template_class_locals() -> dict[str, Any] | None:
+    """When templates are created from inside a closure (ex, during
+    testing, where this is extremely common), we need access to the
+    locals from the closure to resolve type hints. This method relies
+    upon ``inspect`` to extract them.
+
+    Note that this can be very sensitive to where, exactly, you put it
+    within the templatey code. Always put it as close as possible to
+    the public API method, so that the first frame from another module
+    coincides with the call to decorate a template class.
+    """
+    upmodule_frame = _get_first_frame_from_other_module()
+    if upmodule_frame is not None:
+        return upmodule_frame.f_locals
+
+
+def _extract_frame_scope() -> FrameType | None:
+    """When templates are created from inside a closure (ex, during
+    testing, where this is extremely common), and forward references
+    are used, we need a way to differentiate between identically-named
+    templates within different functions of the same module (or the
+    toplevel of the module). We do this by including the frame object
+    on the ForwardReferenceParam whenever we're in a closure. This
+    method relies upon ``inspect`` to extract it.
+
+    Note that this can be very sensitive to where, exactly, you put it
+    within the templatey code. Always put it as close as possible to
+    the public API method, so that the first frame from another module
+    coincides with the call to decorate a template class.
+    """
+    upmodule_frame = _get_first_frame_from_other_module()
+    if upmodule_frame is not None:
+        frame_info = inspect.getframeinfo(upmodule_frame)
+
+        # Handily enough, cpython uses this to indicate that we're not inside
+        # a function currently, which is exactly what we need.
+        if frame_info.function != '<module>':
+            return upmodule_frame
+
+
+def _get_first_frame_from_other_module() -> FrameType | None:
+    """Both of our closure workarounds require walking up the stack
+    until we reach the first frame coming from ^^outside^^ the ~~house~~
+    current module. This performs that lookup.
+
+    **Note that this is pretty fragile.** Or, put a different way: it
+    does exactly what the function name suggest it does: it finds the
+    FIRST frame from another module. That doesn't mean we won't return
+    to this module; it doesn't mean it's from the actual client library,
+    etc. It just means it's the first frame that isn't from this
+    module.
+    """
+    upstack_frame = inspect.currentframe()
+    if upstack_frame is None:
+        return None
+    else:
+        this_module = upstack_module = inspect.getmodule(
+            _extract_template_class_locals)
+        while upstack_module is this_module:
+            if upstack_frame is None:
+                return None
+
+            upstack_frame = upstack_frame.f_back
+            upstack_module = inspect.getmodule(upstack_frame)
+
+    return upstack_frame
+
+
+def _classify_interface_field_flavor(
+        parent_class_type_hints: dict[str, Any],
+        template_field: Field
+        ) -> tuple[InterfaceAnnotationFlavor, type] | None:
+    """For a dataclass field, determines whether it was declared as a
+    var, slot, or content.
+
+    If none of the above, returns None.
+    """
+    # Note that dataclasses don't include the actual type (just a string)
+    # when in __future__ mode, so we need to get them from the parent class
+    # by calling get_type_hints() on it
+    resolved_field_type = parent_class_type_hints[template_field.name]
+    anno_origin = typing.get_origin(resolved_field_type)
+    if anno_origin is Var:
+        nested_type, = typing.get_args(resolved_field_type)
+        return InterfaceAnnotationFlavor.VARIABLE, nested_type
+    elif anno_origin is Slot:
+        nested_type, = typing.get_args(resolved_field_type)
+        return InterfaceAnnotationFlavor.SLOT, nested_type
+    elif anno_origin is Content:
+        nested_type, = typing.get_args(resolved_field_type)
+        return InterfaceAnnotationFlavor.CONTENT, nested_type
+    else:
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingSlotTree:
+    """Remember that the point here is to eventually build a lookup from
+    a ``{type[template]: _SlotTreeNode}``. And we're dealing with
+    forward references to the ``type[template]``, meaning we don't have
+    a key to use for the slot tree lookup. End of story.
+
+    So what we're doing here instead, is constructing the slot tree as
+    best as we can, and keeping track of what nodes need to be populated
+    by the forward reference, once it is resolved.
+
+    When the forward ref is resolved, we can simple copy the tree into
+    all of the insertion nodes, and then store the pending slot tree
+    in the slot tree lookup using the resolved template class.
+    """
+    pending_slot_type: ForwardReferenceParam
+    pending_root_node: _SlotTreeNode
+    insertion_nodes: list[_SlotTreeNode]
+
+
+@dataclass(frozen=True, slots=True)
+class ForwardReferenceParam:
+    """We use this to find all possible ForwardReferenceParam instances
+    for a particular pending template.
+
+    Note that, by definition, forward references can only happen in two
+    situations:
+    ++  within the same module or closure, by something declared later
+        on during execution
+    ++  because of something hidden behind a ``if typing.TYPE_CHECKING``
+        block in imports
+    (Any other scenario would result in import failures preventing the
+    module's execution).
+
+    Names imported behind ``TYPE_CHECKING`` blocks can **only** be
+    resolved using explicit helpers in the ``@template`` decorator.
+    (TODO: need to add those!). There's just no way around that one;
+    by definition, it's a circular import, and the name isn't available
+    at runtime. So you need an escape hatch.
+
+    Therefore, unless passed in an explicit module name because of the
+    aforementioned escape hatch, these must always happen from within
+    the same module as the template itself.
+
+    Furthermore, we make one assumption here for the purposes of
+    doing as much work as possible at import time, ahead of the first
+    call to render a template: that the enclosing template references
+    the nested template by the nested template's proper name, and
+    doesn't rename it.
+
+    The only workaround for a renamed nested template would be to
+    create a dedicated resolution function, to be called at first
+    render time, that re-inspects the template's type annotations, and
+    figures out exactly what type it uses at that point in time. That's
+    a mess, so.... we'll punt on it.
+    """
+    module: str
+    name: str
+    scope: FrameType | None
+
+
+class ForwardReferenceProxyClass(Protocol):
+    REFERENCE_TARGET: ClassVar[ForwardReferenceParam]
+
+
+def is_forward_reference_proxy(
+        obj: object
+        ) -> TypeIs[type[ForwardReferenceProxyClass]]:
+    return isinstance(obj, type) and hasattr(obj, 'REFERENCE_TARGET')
+
+
+def _copy_slot_tree(
+        src_tree: _SlotTreeNode,
+        into_tree: _SlotTreeNode | None = None
+        ) -> tuple[_SlotTreeNode, dict[int, _SlotTreeNode]]:
+    """This creates a copy of an existing slot tree. We use it when
+    merging nested slot trees into parents; otherwise, we end up with
+    a huge mess of "it's not clear what object holds which slot tree"
+    that is very difficult to reason about. This is slightly more memory
+    intensive, but... again, this is much, much easier to reason about.
+
+    Take special note that this preserves reference cycles, which is a
+    bit of a tricky thing.
+
+    Note: if ``into_tree`` is provided, this copies inplace and returns
+    the ``into_tree``. Otherwise, a new tree is created and returned.
+    In both cases, we also return a lookup from
+    ``{id(old_node): copied_node}``.
+    """
+    copied_tree: _SlotTreeNode
+    if into_tree is None:
+        copied_tree = _SlotTreeNode(
+            is_recursive=src_tree.is_recursive,
+            is_terminus=src_tree.is_terminus)
+    else:
+        copied_tree = into_tree
+        copied_tree.is_recursive |= src_tree.is_recursive
+        copied_tree.is_terminus |= src_tree.is_terminus
+
+    # This converts ``id(old_node)`` to the new node instance; it's how we
+    # implement copying reference cycles
+    transmogrified_nodes: dict[int, _SlotTreeNode] = {
+        id(src_tree): copied_tree}
+    copy_stack: list[_SlotTreeTraversalFrame] = [_SlotTreeTraversalFrame(
+        next_subtree_index=0,
+        existing_subtree=copied_tree,
+        insertion_subtree=src_tree)]
+
+    while copy_stack:
+        current_stack_frame = copy_stack[-1]
+        if current_stack_frame.exhausted:
+            copy_stack.pop()
+            continue
+
+        next_slot_route = current_stack_frame.insertion_subtree[
+            current_stack_frame.next_subtree_index]
+        next_slot_name, next_subtree = next_slot_route
+
+        next_subtree_id = id(next_subtree)
+        already_copied_node = transmogrified_nodes.get(next_subtree_id)
+        # This could be either the first time we hit a recursive subtree,
+        # or a non-recursive subtree.
+        if already_copied_node is None:
+            new_subtree = _SlotTreeNode(
+                is_recursive=next_subtree.is_recursive,
+                is_terminus=next_subtree.is_terminus)
+
+            # We only need to do this for recursive subtrees; that's the only
+            # time we need to get a reference back to a previous subtree.
+            if next_subtree.is_recursive:
+                transmogrified_nodes[next_subtree_id] = new_subtree
+
+            current_stack_frame.existing_subtree.append(
+                _SlotTreeRoute(
+                    next_slot_name,
+                    new_subtree,
+                    slot_types=next_slot_route.slot_types))
+            copy_stack.append(_SlotTreeTraversalFrame(
+                next_subtree_index=0,
+                existing_subtree=new_subtree,
+                insertion_subtree=next_subtree))
+
+        else:
+            current_stack_frame.existing_subtree.append(
+                _SlotTreeRoute(
+                    next_slot_name,
+                    already_copied_node,
+                    slot_types=next_slot_route.slot_types))
+
+        current_stack_frame.next_subtree_index += 1
+
+    return copied_tree, transmogrified_nodes
+
+
+def _merge_into_slot_tree(
+        existing_tree: _SlotTreeNode,
+        root_slot_name: str,
+        to_merge_slot_type:
+            type[TemplateParamsInstance] | ForwardReferenceParam,
+        to_merge: _SlotTreeNode
+        ) -> dict[int, _SlotTreeNode]:
+    """This traverses the existing tree, merging in the slot_name and
+    its subtrees into the correct locations in the existing slot tree,
+    recursively.
+
+    This is needed because unions can have slots with overlapping slot
+    names, but we don't want to redo a ton of tree recursion.
+
+    In theory, this might result in some edge case scenarios where two
+    effectively identical templates within a union, one of which calls
+    an env function and one of which doesn't, might actually result in
+    some unnecessary calls to the env function during prepopulation.
+    I'm honestly not sure either way; we'd need more testing to verify
+    either way. The solution in that case would probably be some kind
+    of instance check to verify just before running the function that
+    it was actually the expected instance type / has the expected
+    function calls.
+
+    We return a lookup of ``{id(source_node): dest_node}``, which can
+    be used for recording and/or resolving pending forward refs.
+    """
+    all_transmogrified_nodes: dict[int, _SlotTreeNode] = {}
+
+    # Counterintuitive: since were MERGING trees, the existing_subtree is
+    # actually the DESTINATION, and the insertion_subtree the source!
+    merge_stack: list[_SlotTreeTraversalFrame] = [_SlotTreeTraversalFrame(
+        next_subtree_index=0,
+        existing_subtree=existing_tree,
+        insertion_subtree=_SlotTreeNode([
+            _SlotTreeRoute.from_slot_type(
+                root_slot_name,
+                to_merge,
+                slot_type=to_merge_slot_type)]))]
+    # Yes, in theory, this one specific operation of merging trees would be
+    # faster if the trees were dicts instead of iterative structures. But
+    # we're not optimizing for tree merging; we're optimizing for rendering!
+    # And in that case, we're better off with a simple iterative structure.
+    while merge_stack:
+        current_stack_frame = merge_stack[-1]
+        if current_stack_frame.exhausted:
+            merge_stack.pop()
+            continue
+
+        next_slot_route = current_stack_frame.insertion_subtree[
+            current_stack_frame.next_subtree_index]
+        next_slot_name, next_subtree = next_slot_route
+
+        if current_stack_frame.existing_subtree.has_route_for(next_slot_name):
+            next_existing_route = (
+                current_stack_frame.existing_subtree.get_route_for(
+                    next_slot_name))
+            __, next_existing_subtree = next_existing_route
+
+            # We haven't hit a leaf node yet, so we need to keep looking
+            # deeper.
+            if next_subtree:
+                merge_stack.append(_SlotTreeTraversalFrame(
+                    next_subtree_index=0,
+                    existing_subtree=next_existing_subtree,
+                    insertion_subtree=next_subtree))
+
+            # Note that both of the remaining cases indicate that
+            # we hit a leaf node on the to-merge tree. Note though that
+            # this isn't definitively also a leaf node on the existing
+            # tree, in case you have a union between two very similar, but
+            # not identical, trees. Hence the two cases.
+            elif next_existing_subtree:
+                # TODO: we actually have most of the puzzle pieces for this
+                # already in place, we just need to wire up the terminus
+                raise NotImplementedError('''
+                    You've hit a very particular edge case that we haven't
+                    implemented yet.
+
+                    Specifically, you have two very similar set of template
+                    slot trees, but they differ slightly. One of them has
+                    a "terminus" node at a particular point -- ie, a leaf
+                    node for that particular template slot class -- while
+                    the other continues on deeper within the slot tree
+                    **to the same template slot class**.
+
+                    We really need to update the slot tree to have
+                    dedicated leaf node objects, but until then, we can't
+                    accommodate this edge case without introducing bugs.
+
+                    If you encounter this, please search for and/or file
+                    an issue on github!
+                    ''')
+                copied_leaf: _SlotTreeNode = []
+                current_stack_frame.existing_subtree.append(
+                    (next_slot_name, copied_leaf))
+                all_transmogrified_nodes[id(next_subtree)] = copied_leaf
+
+            # In this case, it really IS identical, but we've nothing to do.
+            else:
+                pass
+
+            next_existing_subtree.is_recursive |= next_subtree.is_recursive
+            next_existing_subtree.is_terminus |= next_subtree.is_terminus
+            if next_existing_subtree.is_recursive:
+                all_transmogrified_nodes[id(next_subtree)] = (
+                    next_existing_subtree)
+            next_existing_route.slot_types.update(next_slot_route.slot_types)
+
+        # Note because it's almost above the fold: this is the "we don't have
+        # an existing route for the next_slot_name" case.
+        else:
+            copied_tree, copied_node_lookup = _copy_slot_tree(next_subtree)
+            current_stack_frame.existing_subtree.append(
+                # Just as a reminder, this is deepening the tree by 1 level
+                _SlotTreeRoute(
+                    next_slot_name,
+                    copied_tree,
+                    slot_types=next_slot_route.slot_types))
+            all_transmogrified_nodes.update(copied_node_lookup)
+
+        current_stack_frame.next_subtree_index += 1
+
+    return all_transmogrified_nodes
+
+
+@dataclass(slots=True)
+class _SlotTreeTraversalFrame:
+    next_subtree_index: int
+    existing_subtree: _SlotTreeNode
+    insertion_subtree: _SlotTreeNode
+
+    @property
+    def exhausted(self) -> bool:
+        """Returns True if the to_merge_subtree has been exhausted, and
+        there are no more subtrees to merge.
+        """
+        return self.next_subtree_index >= len(self.insertion_subtree)
+
+
+# Note: mutablemapping because otherwise chainmap complains. Even though they
+# aren't actually implemented, this is a quick way of getting typing to work
+@dataclass(kw_only=True, slots=True)
+class _TypehintForwardrefLookup(MutableMapping[str, type]):
+    template_module: str
+    template_scope: FrameType | None
+    captured_refs: set[ForwardReferenceParam] = field(default_factory=set)
+
+    def __getitem__(self, key: str) -> type:
+        forward_ref = ForwardReferenceParam(
+            module=self.template_module,
+            name=key,
+            scope=self.template_scope)
+
+        class ForwardReferenceProxyClass:
+            """When we return a forward reference, we want to retain all
+            of the expected behavior with types -- unions via ``|``,
+            etc -- and therefore, we want to return a proxy class
+            instead of the forward reference itself.
+            """
+            REFERENCE_TARGET = forward_ref
+
+        self.captured_refs.add(forward_ref)
+        return ForwardReferenceProxyClass
+
+    def __iter__(self) -> Iterator[str]:
+        raise NotImplementedError
+
+    def __len__(self) -> int:
+        raise NotImplementedError
+
+    def __setitem__(self, key, value) -> None:
+        raise NotImplementedError
+
+    def __delitem__(self, key) -> None:
+        raise NotImplementedError
+
+
 @dataclass_transform(field_specifiers=(param, field, Field))
 def make_template_definition[T: type](
         cls: T,
@@ -763,34 +1463,58 @@ def make_template_definition[T: type](
     try:
         template_type_hints = typing.get_type_hints(cls)
     except NameError as exc:
-        template_type_hints = None
+        logger.info(dedent('''\
+            Failed to resolve template type hints on first pass. This could be
+            indicative of a bug, or it might occur in normal situations if:
+            ++  you're defining the template within a closure. Here, we'll
+                attempt to infer the locals via inspect.currentframe, but not
+                all platforms support that, which can lead to failures
+            ++  the type hint is a forward reference.
+
+            In both cases, we'll wrap the request into a
+            ``ForwardReferenceParam``, which will then hopefully be
+            resolved as soon as the forward reference is declared.
+            If it's never resolved, however, we will raise whenever
+            ``render`` is called.
+            '''),
+            exc_info=exc)
+
+        # There's a method to the madness here.
+        # globalns needs to be strictly a dict, because it gets delegated into
+        # ``eval``, which requires one. Which means we can only use the localns
+        # to intercept missing forward references. But that, then, means that
+        # we need to recover the existing check for the actual globals, since
+        # otherwise **all** global names would be overwritten by the forward
+        # reference.
+        template_module = cls.__module__
+        forwardref_lookup = _TypehintForwardrefLookup(
+            template_module=template_module,
+            template_scope=_extract_frame_scope())
+        # This is the same as the current implementation of get_type_hints
+        # in cpython for classes:
+        # https://github.com/python/cpython/blob/0045100ccbc3919e8990fa59bc413fe38d21b075/Lib/typing.py#L2325
+        template_globals = getattr(
+            sys.modules.get(template_module, None), '__dict__', {})
+
         maybe_locals = _extract_template_class_locals()
-        if maybe_locals is not None:
-            try:
-                template_type_hints = typing.get_type_hints(
-                    cls, localns=maybe_locals)
+        if maybe_locals is None:
+            prioritized_lookups = (
+                template_globals,
+                # Fun fact: these aren't included in the other globals!
+                __builtins__,
+                forwardref_lookup)
 
-            # We'll just revert to the parent exception in this case
-            except NameError:
-                pass
+        else:
+            prioritized_lookups = (
+                maybe_locals,
+                template_globals,
+                # Fun fact: these aren't included in the other globals!
+                __builtins__,
+                forwardref_lookup)
 
-        if template_type_hints is None:
-            exc.add_note(
-                dedent('''\
-                This NameError was raised while trying to get the type hints
-                assigned to a class decorated with @templatey.template.
-                This typically means you were creating a template within a
-                closure, and we were unable to infer the locals via
-                inspect.currentframe (probably because your current python
-                platform doesn't support it). Alternatively, this may be the
-                result of attempting to use a forward reference within the
-                type hint; note that, though the type will resolve correctly,
-                the actual class still isn't defined at this point, preventing
-                type hint resolution. In that case, simply make sure to declare
-                any child slot templates before their parents reference them.
-                '''
-                ))
-            raise exc
+        # Because of our forward lookup, this will always succeed
+        template_type_hints = typing.get_type_hints(
+            cls, localns=ChainMap(*prioritized_lookups))
 
     slots = {}
     vars_ = {}
@@ -827,57 +1551,59 @@ def make_template_definition[T: type](
                 'templatey.prerenderer')
 
     cls._templatey_signature = TemplateSignature.new(
+        for_cls=cls,
         slots=slots,
         vars_=vars_,
         content=content)
     converter_cls = namedtuple('TemplateyConverters', tuple(prerenderers))
     cls._templatey_prerenderers = converter_cls(**prerenderers)
+    _resolve_forward_references(cls)
     return cls
 
 
-def _extract_template_class_locals() -> dict[str, Any] | None:
-    upstack_frame = inspect.currentframe()
-    if upstack_frame is None:
-        return None
-    else:
-        this_module = upstack_module = inspect.getmodule(
-            _extract_template_class_locals)
-        while upstack_module is this_module:
-            if upstack_frame is None:
-                return None
+def _resolve_forward_references(
+        pending_template_cls: type[TemplateIntersectable]):
+    """The very last thing to do before we return the class after
+    template decoration is to resolve all forward references inside the
+    class. To do that, we first need to construct the corresponding
+    ForwardReferenceParam and check for it in the pending forward refs
+    lookup.
 
-            upstack_frame = upstack_frame.f_back
-            upstack_module = inspect.getmodule(upstack_frame)
-
-    if upstack_frame is not None:
-        return upstack_frame.f_locals
-
-
-def _classify_interface_field_flavor(
-        parent_class_type_hints: dict[str, Any],
-        template_field: Field
-        ) -> tuple[InterfaceAnnotationFlavor, type] | None:
-    """For a dataclass field, determines whether it was declared as a
-    var, slot, or content.
-
-    If none of the above, returns None.
+    If we find one, we then need to update the values there, while
+    checking for and correctly handling recursion.
     """
-    # Note that dataclasses don't include the actual type (just a string)
-    # when in __future__ mode, so we need to get them from the parent class
-    # by calling get_type_hints() on it
-    resolved_field_type = parent_class_type_hints[template_field.name]
-    anno_origin = typing.get_origin(resolved_field_type)
-    if anno_origin is Var:
-        nested_type, = typing.get_args(resolved_field_type)
-        return InterfaceAnnotationFlavor.VARIABLE, nested_type
-    elif anno_origin is Slot:
-        nested_type, = typing.get_args(resolved_field_type)
-        return InterfaceAnnotationFlavor.SLOT, nested_type
-    elif anno_origin is Content:
-        nested_type, = typing.get_args(resolved_field_type)
-        return InterfaceAnnotationFlavor.CONTENT, nested_type
-    else:
-        return None
+    lookup_key = ForwardReferenceParam(
+        module=pending_template_cls.__module__,
+        name=pending_template_cls.__name__,
+        scope=_extract_frame_scope())
+    print(lookup_key)
+    # raise NotImplementedError(
+    #     '''
+        
+        
+    #     TODO LEFT OFF HERE
+        
+        
+    #     we're not getting the correct frames, because the proxy we're using
+    #     to construct them is pulling the frame from stdlib collections instead
+    #     of the caller library. oops.
+        
+    #     otherwise, basically, you just need to finish what's described
+    #     in the docstring.
+        
+    #     the other option would be to ... shit, I'm not even sure, tbh.
+    #     the whole tree copying business would have to be moved, I think?
+    #     if you wanted to do this as a "on first render" kind of thing?
+    #     plus that would make the render driver really ugly.
+
+    #     maybe it would be an "on first load"? that would at least be better
+    #     than in the render driver.
+        
+    #     but still... really not sure how to approach this if I can't get the
+    #     frame scope to match up.
+        
+        
+    #     ''')
 
 
 @dataclass(frozen=True, slots=True)

--- a/src_py/templatey/templates.py
+++ b/src_py/templatey/templates.py
@@ -1055,7 +1055,7 @@ class TemplateSignature:
             # Remember that we're in the middle of constructing the signature
             # for a new template class. If the nested class (from the slot) was
             # depending on the class we're still constructing, it hasn't yet
-            # been updated with the resovlved class. Therefore, instead of
+            # been updated with the resolved class. Therefore, instead of
             # needing to come back and fix up any recursive forward refs later,
             # we can simply do them right here, right now.
             # Also note that we'll NEVER have an existing pending tree for
@@ -1071,6 +1071,7 @@ class TemplateSignature:
                     resolved_cls=template_cls,
                     resolved_slot_tree_lookup=slot_tree_lookup,
                     resolved_pending_ref_lookup=pending_ref_lookup)
+                continue
 
             # Remember that we're simply transforming the existing pending ref
             # tree from the nested slot into a pending ref tree on the

--- a/tests_py/test_templates.py
+++ b/tests_py/test_templates.py
@@ -330,6 +330,7 @@ class TestMakeTemplateDefinition:
             bar: Slot[Bar]  # type: ignore
         foo_xable = cast(TemplateIntersectable, Foo)
 
+        assert not forward_ref_registry
         assert len(retval._templatey_signature._pending_ref_lookup) == 0
         assert not forward_ref_registry
         assert Foo in foo_xable._templatey_signature._slot_tree_lookup

--- a/uv.lock
+++ b/uv.lock
@@ -406,7 +406,7 @@ name = "templatey"
 source = { editable = "." }
 dependencies = [
     { name = "docnote" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -436,7 +436,7 @@ test = [
 requires-dist = [
     { name = "anyio", marker = "extra == 'async-prebaked'", specifier = ">=4.6.2" },
     { name = "docnote", specifier = ">=2025.5.26.1" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.12.2" },
+    { name = "typing-extensions", specifier = ">=4.12.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
# Summary

This PR adds support for declaring template slots using forward refs, including recursively.

# Details

This was way harder than expected. In hindsight, building the slot tree would probably be best done upon first template load, as opposed to at template module import time.

# Tests

Could be better, tbh. In addition to an E2E test (a pretty realistic one IMO, based on the actual application I have that prompted this feature), I also added some unit tests in ``test_templates``, but they have pretty low specificity. Debugging issues in tests is still a huge mess, because you just see very coarse "something in these 2k LoC failed" and then have to add in tons of debug prints.