### PR TITLE
Run async env function invocations in taskgroup

### DIFF
--- a/benchmarks/templatey_benchmark_2025-07-14-1752493476.json
+++ b/benchmarks/templatey_benchmark_2025-07-14-1752493476.json
@@ -1,0 +1,22 @@
+{
+    "jinja":
+    {
+        "simple.load": 0.0005364659002516419,
+        "simple.render": 0.0005226082001172471,
+        "nested_comp.load": 0.0012235711998655461,
+        "nested_comp.render": 0.0005923578002548311,
+        "nested_comp_funky.render.sync": 0.0005752224997559096,
+        "nested_comp_funky.render.asyncio": 0.00008311329947900959,
+        "nested_comp_funky.render.trio": 0.00010984899991308339
+    },
+    "templatey":
+    {
+        "simple.load": 3.41900042258203E-7,
+        "simple.render": 0.000022637600457528605,
+        "nested_comp.load": 3.5620006383396687E-7,
+        "nested_comp.render": 0.0001030577995989006,
+        "nested_comp_funky.render.sync": 0.0001420115002838429,
+        "nested_comp_funky.render.asyncio": 0.00025264550012070686,
+        "nested_comp_funky.render.trio": 0.0003711197001975961
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-async_prebaked = [
+async = [
     "anyio >= 4.6.2",
 ]
 

--- a/tests_py/test_environments.py
+++ b/tests_py/test_environments.py
@@ -533,7 +533,7 @@ class TestRenderEnvironment:
             result_key=object(),
             provenance=Provenance())
 
-        result = render_env.execute_env_function_sync(request)
+        result = render_env._execute_env_function_sync(request)
         assert isinstance(result, FuncExecutionResult)
         assert result.retval == ('foo', 'bar', 'baz')
 
@@ -551,6 +551,6 @@ class TestRenderEnvironment:
             result_key=object(),
             provenance=Provenance())
 
-        result = await render_env.execute_env_function_async(request)
+        result = await render_env._execute_env_function_async(request)
         assert isinstance(result, FuncExecutionResult)
         assert result.retval == ('foo', 'bar', 'baz')

--- a/uv.lock
+++ b/uv.lock
@@ -410,7 +410,7 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-async-prebaked = [
+async = [
     { name = "anyio" },
 ]
 
@@ -434,7 +434,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio", marker = "extra == 'async-prebaked'", specifier = ">=4.6.2" },
+    { name = "anyio", marker = "extra == 'async'", specifier = ">=4.6.2" },
     { name = "docnote", specifier = ">=2025.5.26.1" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
 ]


### PR DESCRIPTION
# Summary

Previously, we've been running async env functions one at a time in series. This shouldn't have any effect on overall throughput (requests per second), since the total number of yields to the event loop will always be the same for the same number of function invocations. However, this will increase the wall time for rendering templates with multiple loads/function invocations. Additionally, if the loader is doing network operations, that delay could be substantial.

This PR makes ``anyio`` required for all async, and then runs every template env request (function execution or template body loading) in a parallel task group.

# Notes

Note that this comes at a slight hit to the wall-time performance for lightweight env functions, or for templates that only use single env requests and have very fast template load times (or preloaded templates, as in benchmarks).