### PR TITLE
Add support for template data refs

### DIFF
--- a/src_py/templatey/_bootstrapping.py
+++ b/src_py/templatey/_bootstrapping.py
@@ -32,6 +32,7 @@ PARSED_EMPTY_TEMPLATE = ParsedTemplateResource(
     content_names=frozenset(),
     slot_names=frozenset(),
     slots={},
+    data_names=frozenset(),
     function_names=frozenset(),
     function_calls={})
 EMPTY_TEMPLATE_XABLE = cast(type[TemplateIntersectable], EmptyTemplate)

--- a/src_py/templatey/_signature.py
+++ b/src_py/templatey/_signature.py
@@ -52,11 +52,12 @@ class TemplateSignature:
     template_cls_ref: ref[TemplateClass]
     _forward_ref_lookup_key: ForwardRefLookupKey
 
+    data_names: frozenset[str]
+    var_names: frozenset[str]
+    content_names: frozenset[str]
     # Note that these are all ONLY the direct nesteds; these do not include
     # anything from deeper in the slot tree.
     slot_names: frozenset[str]
-    var_names: frozenset[str]
-    content_names: frozenset[str]
     dynamic_class_slot_names: frozenset[str]
 
     _dynamic_class_slot_tree: DynamicClassSlotTreeNode
@@ -117,6 +118,7 @@ class TemplateSignature:
             template_cls: type,
             slots: dict[str, _SlotAnnotation],
             dynamic_class_slot_names: set[str],
+            data: dict[str, None],
             vars_: dict[str, type | type[ForwardReferenceProxyClass]],
             content: dict[str, type | type[ForwardReferenceProxyClass]],
             *,
@@ -241,6 +243,7 @@ class TemplateSignature:
                 template_cls,
                 dynamic_class_slot_names,
                 tree_wip),
+            data_names=frozenset(data),
             var_names=var_names,
             content_names=content_names,
             _slot_tree_lookup=tree_wip,

--- a/src_py/templatey/_types.py
+++ b/src_py/templatey/_types.py
@@ -29,6 +29,7 @@ class InterfaceAnnotationFlavor(Enum):
     VARIABLE = 'var'
     CONTENT = 'content'
     DYNAMIC = 'dynamic'
+    DATA = 'data'
 
 
 @dataclass(frozen=True)

--- a/src_py/templatey/environments.py
+++ b/src_py/templatey/environments.py
@@ -312,6 +312,7 @@ class RenderEnvironment:
         slot_names = template_signature.slot_names
         dynamic_class_slot_names = template_signature.dynamic_class_slot_names
         content_names = template_signature.content_names
+        data_names = template_signature.data_names
 
         if strict_mode:
             variables_mismatch = (
@@ -321,6 +322,8 @@ class RenderEnvironment:
                 ^ (slot_names | dynamic_class_slot_names))
             content_mismatch = (
                 parsed_template_resource.content_names ^ content_names)
+            data_mismatch = (
+                parsed_template_resource.data_names ^ data_names)
 
         else:
             variables_mismatch = (
@@ -330,12 +333,20 @@ class RenderEnvironment:
                 - (slot_names | dynamic_class_slot_names))
             content_mismatch = (
                 parsed_template_resource.content_names - content_names)
+            data_mismatch = (
+                parsed_template_resource.data_names - data_names)
 
-        if variables_mismatch or slot_mismatch or content_mismatch:
+        if (
+            variables_mismatch
+            or slot_mismatch
+            or content_mismatch
+            or data_mismatch
+        ):
             raise MismatchedTemplateSignature(
                 'Template interface variables, content, or slots did not '
                 + 'match the template text!', template_class,
-                variables_mismatch, slot_mismatch, content_mismatch)
+                variables_mismatch, slot_mismatch, content_mismatch,
+                data_mismatch)
 
         return True
 

--- a/tests_py/test_e2e.py
+++ b/tests_py/test_e2e.py
@@ -874,3 +874,26 @@ class TestApiE2E:
                 foo2=[NestedTemplate(value=...)]))
 
         assert render_result == 'foo1 foo2'
+
+    def test_func_with_data_ref(self):
+        """A template with two identical union slot types under
+        different slot names must successfully render.
+        """
+        template_txt = '''yolo {@echo_chamber(data.bar)}'''
+
+        @template(html, 'template_txt')
+        class FakeTemplate:
+            bar: str
+
+        def echo_chamber(val: str) -> list[str]:
+            return [val]
+
+        render_env = RenderEnvironment(
+            env_functions=(echo_chamber,),
+            template_loader=DictTemplateLoader(
+                templates={
+                    'template_txt': template_txt,}))
+
+        render_result = render_env.render_sync(FakeTemplate(bar='oloy'))
+
+        assert render_result == 'yolo oloy'

--- a/tests_py/test_environments.py
+++ b/tests_py/test_environments.py
@@ -407,6 +407,7 @@ class TestRenderEnvironment:
         class FakeTemplate:
             foo: Var[str]
             bar: Slot[FakeGlobalTemplate]
+            baz: str
 
         loader = DictTemplateLoader(templates={'fake': 'foobar'})
         loader_mock = Mock(spec=loader.load_async, wraps=loader.load_async)
@@ -431,7 +432,7 @@ class TestRenderEnvironment:
                 content_names=frozenset(),
                 slot_names=frozenset({'bar'}),
                 slots={},
-                data_names=frozenset(),
+                data_names=frozenset({'baz'}),
                 function_names=frozenset(),
                 function_calls={}),
             strict_mode=True)

--- a/tests_py/test_environments.py
+++ b/tests_py/test_environments.py
@@ -282,6 +282,7 @@ class TestRenderEnvironment:
                 content_names=frozenset(),
                 slot_names=frozenset(),
                 slots={},
+                data_names=frozenset(),
                 function_names=frozenset(),
                 function_calls={}))
 
@@ -322,6 +323,7 @@ class TestRenderEnvironment:
                 content_names=frozenset(),
                 slot_names=frozenset(),
                 slots={},
+                data_names=frozenset(),
                 function_names=frozenset({'href'}),
                 function_calls={}))
 
@@ -350,6 +352,7 @@ class TestRenderEnvironment:
                     content_names=frozenset(),
                     slot_names=frozenset(),
                     slots={},
+                    data_names=frozenset(),
                     function_names=frozenset({'href'}),
                     function_calls={'href': (InterpolatedFunctionCall(
                         call_args_exp=None,
@@ -385,6 +388,7 @@ class TestRenderEnvironment:
                     content_names=frozenset(),
                     slot_names=frozenset(),
                     slots={},
+                    data_names=frozenset(),
                     function_names=frozenset({'href'}),
                     function_calls={'href': (InterpolatedFunctionCall(
                         call_args_exp=None,
@@ -427,6 +431,7 @@ class TestRenderEnvironment:
                 content_names=frozenset(),
                 slot_names=frozenset({'bar'}),
                 slots={},
+                data_names=frozenset(),
                 function_names=frozenset(),
                 function_calls={}),
             strict_mode=True)
@@ -461,6 +466,7 @@ class TestRenderEnvironment:
                     content_names=frozenset({'foo'}),
                     slot_names=frozenset(),
                     slots={},
+                    data_names=frozenset(),
                     function_names=frozenset(),
                     function_calls={}),
                 strict_mode=True)
@@ -488,6 +494,7 @@ class TestRenderEnvironment:
                     content_names=frozenset(),
                     slot_names=frozenset(),
                     slots={},
+                    data_names=frozenset(),
                     function_names=frozenset(),
                     function_calls={}),
                 strict_mode=True)
@@ -514,6 +521,7 @@ class TestRenderEnvironment:
                 content_names=frozenset(),
                 slot_names=frozenset(),
                 slots={},
+                data_names=frozenset(),
                 function_names=frozenset(),
                 function_calls={}),
             strict_mode=False)

--- a/tests_py/test_parser.py
+++ b/tests_py/test_parser.py
@@ -5,6 +5,7 @@ from templatey.parser import InterpolatedSlot
 from templatey.parser import InterpolatedVariable
 from templatey.parser import InterpolationConfig
 from templatey.parser import NestedContentReference
+from templatey.parser import NestedDataReference
 from templatey.parser import NestedVariableReference
 from templatey.parser import parse
 
@@ -235,6 +236,26 @@ class TestParse:
         assert not parsed.slot_names
         assert not parsed.content_names
         assert parsed.variable_names == frozenset({'baz'})
+        assert parsed.function_names == frozenset({'bar'})
+        assert 'bar' in parsed.function_calls
+
+    def test_curlybrace_with_function_params_data_ref(self):
+        template = 'foo {@bar(data.baz)}'
+        parsed = parse(template, NamedInterpolator.CURLY_BRACES)
+
+        assert len(parsed.parts) == 2
+        assert parsed.parts[0] == 'foo '
+        assert InterpolatedFunctionCall(
+            call_args_exp=None,
+            call_kwargs_exp=None,
+            part_index=1,
+            name='bar',
+            call_args=[NestedDataReference(name='baz')],
+            call_kwargs={})._matches(parsed.parts[1])
+        assert not parsed.slot_names
+        assert not parsed.content_names
+        assert not parsed.variable_names
+        assert parsed.data_names == frozenset({'baz'})
         assert parsed.function_names == frozenset({'bar'})
         assert 'bar' in parsed.function_calls
 

--- a/tests_py/test_renderer.py
+++ b/tests_py/test_renderer.py
@@ -75,6 +75,7 @@ class TestRenderDriver:
                     slot_names=frozenset(),
                     slots={},
                     function_names=frozenset(),
+                    data_names=frozenset(),
                     function_calls={}))
             return
             yield
@@ -128,6 +129,7 @@ class TestRenderDriver:
                     slot_names=frozenset(),
                     slots={},
                     function_names=frozenset({'fakefunc'}),
+                    data_names=frozenset(),
                     function_calls={'fakefunc': (fake_interpolated_call,)}))
             render_context.function_precall[fake_cache_key] = (
                 FuncExecutionResult(
@@ -184,6 +186,7 @@ class TestRenderDriver:
                     content_names=frozenset(),
                     slot_names=frozenset(),
                     slots={},
+                    data_names=frozenset(),
                     function_names=frozenset(),
                     function_calls={}))
             return
@@ -236,6 +239,7 @@ class TestRenderContext:
                 content_names=frozenset(),
                 slot_names=frozenset(),
                 slots={},
+                data_names=frozenset(),
                 function_names=frozenset(),
                 function_calls={})
 
@@ -283,6 +287,7 @@ class TestRenderContext:
                     content_names=frozenset(),
                     slot_names=frozenset(),
                     slots={},
+                    data_names=frozenset(),
                     function_names=frozenset({'fakefunc'}),
                     function_calls={'fakefunc': (fake_interpolated_call,)})
 
@@ -337,6 +342,7 @@ class TestRenderContext:
                     content_names=frozenset(),
                     slot_names=frozenset(),
                     slots={},
+                    data_names=frozenset(),
                     function_names=frozenset({'fakefunc'}),
                     function_calls={'fakefunc': (fake_interpolated_call,)})
 

--- a/tests_py/test_templates.py
+++ b/tests_py/test_templates.py
@@ -534,6 +534,22 @@ class TestMakeTemplateDefinition:
         assert len(signature.var_names) == 1
         assert 'bar' in signature.var_names
 
+    def test_supports_data(self):
+        """Non-param dataclass fields must be detected as template data.
+        """
+        class FakeTemplate:
+            foo: str
+
+        retval = cast(type[TemplateIntersectable], make_template_definition(
+            FakeTemplate,
+            dataclass_kwargs={},
+            template_resource_locator=object(),
+            template_config=fake_template_config))
+        signature = retval._templatey_signature
+
+        assert len(signature.data_names) == 1
+        assert 'foo' in signature.data_names
+
     def test_content_extraction(self):
         """Fields declared with Content[...] must be correctly detected
         and stored on the class.
@@ -565,20 +581,6 @@ class TestMakeTemplateDefinition:
             template_resource_locator=object(),
             template_config=fake_template_config)
         assert is_dataclass(retval)
-
-    def test_requires_interface_typehint(self):
-        """Template type definitions must only include Vars, Contents,
-        and Slots, and must error if anything else is passed.
-        """
-        with pytest.raises(TypeError):
-            class FakeTemplate:
-                foo: str
-
-            make_template_definition(
-                FakeTemplate,
-                dataclass_kwargs={},
-                template_resource_locator=object(),
-                template_config=fake_template_config)
 
     def test_supports_passthrough(self):
         """Dataclass kwargs must be forwarded to the dataclass


### PR DESCRIPTION
# Summary

Previously, we'd disallowed any non-parameter (ie, non-``[Slot | Var | Content]``) fields within template classes. This posed several challenges:

+ if you're including a parameter strictly so it can be passed to an env function, and never shows up in the actual template content, it's not clear if it should be a slot, var, or content
+ it's actually relatively common for env functions to want arbitrary parameters
+ it's just... well, overly-restrictive, and prevents a template from doing double-duty as a general-purpose dataclass. Now, that's probably not something I want to encourange, but it also shouldn't be strictly impossible to do

Therefore, this PR allows for template classes to define arbitrary dataclass fields. These are then interpreted as template "data", which can then be passed to function invocations (but **cannot** be used directly by interpolations). This presents, I think, the ideal balance.

# Testing

I added dedicated unit tests for parsing, template def, and rendering, and added an E2E render test as well.