### PR TITLE
Add template segment modifiers

### DIFF
--- a/benchmarks/templatey_benchmark_2025-07-14-1752533158.json
+++ b/benchmarks/templatey_benchmark_2025-07-14-1752533158.json
@@ -1,0 +1,22 @@
+{
+    "jinja":
+    {
+        "simple.load": 0.000545698500063736,
+        "simple.render": 0.000536211500002537,
+        "nested_comp.load": 0.001264360199565999,
+        "nested_comp.render": 0.0006101701999432407,
+        "nested_comp_funky.render.sync": 0.0006230943998089061,
+        "nested_comp_funky.render.asyncio": 0.00008333179977489635,
+        "nested_comp_funky.render.trio": 0.00010885979956947267
+    },
+    "templatey":
+    {
+        "simple.load": 3.745999420061708E-7,
+        "simple.render": 0.000023284300114028155,
+        "nested_comp.load": 3.9190013194456695E-7,
+        "nested_comp.render": 0.00010311799996998161,
+        "nested_comp_funky.render.sync": 0.00015479940053774043,
+        "nested_comp_funky.render.asyncio": 0.00025125180062605067,
+        "nested_comp_funky.render.trio": 0.00037272549892077223
+    }
+}

--- a/src_py/templatey/_provenance.py
+++ b/src_py/templatey/_provenance.py
@@ -9,9 +9,9 @@ from templatey._slot_tree import SlotTreeNode
 from templatey._types import TemplateClass
 from templatey._types import TemplateInstanceID
 from templatey._types import TemplateParamsInstance
-from templatey.parser import NestedContentReference
-from templatey.parser import NestedVariableReference
 from templatey.parser import ParsedTemplateResource
+from templatey.parser import TemplateInstanceContentRef
+from templatey.parser import TemplateInstanceVariableRef
 
 
 @dataclass(slots=True, frozen=True)
@@ -92,7 +92,7 @@ class Provenance:
             if encloser_param_name in encloser_overrides:
                 value = encloser_overrides[encloser_param_name]
 
-                if isinstance(value, NestedContentReference):
+                if isinstance(value, TemplateInstanceContentRef):
                     encloser_slot_key = encloser.encloser_slot_key
                     encloser_param_name = value.name
                     value = ...
@@ -140,7 +140,7 @@ class Provenance:
             if encloser_param_name in encloser_overrides:
                 value = encloser_overrides[encloser_param_name]
 
-                if isinstance(value, NestedVariableReference):
+                if isinstance(value, TemplateInstanceVariableRef):
                     encloser_slot_key = encloser.encloser_slot_key
                     encloser_param_name = value.name
                     value = ...

--- a/src_py/templatey/_slot_tree.py
+++ b/src_py/templatey/_slot_tree.py
@@ -1343,8 +1343,6 @@ def extract_dynamic_class_slot_types(  # noqa: C901, PLR0912, PLR0915
                 slot_name = frame._ordered_slot_names[
                     frame.target_slot_name_index]
                 target_instance_index = frame.target_instance_index
-                print(target_instance_index)
-                print(active_instance_id)
 
                 # As with subtree checking, this is effectively a nested stack,
                 # but we're maintaining state within the current frame to

--- a/src_py/templatey/_types.py
+++ b/src_py/templatey/_types.py
@@ -18,6 +18,7 @@ from typing_extensions import TypeIs
 if typing.TYPE_CHECKING:
     from _typeshed import DataclassInstance
 
+    from templatey.templates import SegmentModifier
     from templatey.templates import TemplateConfig
     from templatey.templates import TemplateSignature
 else:
@@ -196,6 +197,7 @@ class TemplateIntersectable(Protocol):
     # Field names match the field names from the params; the value is gathered
     # from the metadata value on the field.
     _templatey_prerenderers: ClassVar[NamedTuple]
+    _templatey_segment_modifiers: ClassVar[tuple[SegmentModifier]]
 
 
 # Note: we don't need cryptographically secure IDs here, so let's preserve

--- a/src_py/templatey/environments.py
+++ b/src_py/templatey/environments.py
@@ -288,9 +288,10 @@ class RenderEnvironment:
                         unmodified_part,
                         part_index=next(part_index_counter)))
 
-            parsed_template_resource = dc_replace(
-                parsed_template_resource,
-                parts=tuple(parts_after_modification))
+            # Note: cannot just do dc_replace; we have a bunch more bookkeeping
+            # than that!
+            parsed_template_resource = ParsedTemplateResource.from_parts(
+                parts_after_modification)
 
             if override_validation_strictness is None:
                 strict_mode = self.strict_interpolation_validation
@@ -547,7 +548,8 @@ def _coerce_modified_segment(
     parsed template resource part, including a part index.
     """
     if isinstance(modified_segment, str):
-        return LiteralTemplateString(str, part_index=next(part_index_counter))
+        return LiteralTemplateString(
+            modified_segment, part_index=next(part_index_counter))
 
     elif isinstance(modified_segment, EnvFuncInvocationRef):
         return InterpolatedFunctionCall(

--- a/src_py/templatey/environments.py
+++ b/src_py/templatey/environments.py
@@ -4,6 +4,8 @@ from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Sequence
 from dataclasses import dataclass
+from dataclasses import replace as dc_replace
+from itertools import count
 from typing import Literal
 from typing import Optional
 from typing import Protocol
@@ -24,12 +26,21 @@ from templatey.exceptions import MismatchedRenderColor
 from templatey.exceptions import MismatchedTemplateEnvironment
 from templatey.exceptions import MismatchedTemplateSignature
 from templatey.exceptions import TemplateyException
+from templatey.parser import InterpolatedContent
+from templatey.parser import InterpolatedFunctionCall
+from templatey.parser import InterpolatedSlot
+from templatey.parser import InterpolatedVariable
+from templatey.parser import InterpolationConfig
+from templatey.parser import LiteralTemplateString
 from templatey.parser import ParsedTemplateResource
+from templatey.parser import TemplateInstanceContentRef
+from templatey.parser import TemplateInstanceVariableRef
 from templatey.parser import parse
 from templatey.renderer import FuncExecutionRequest
 from templatey.renderer import FuncExecutionResult
 from templatey.renderer import RenderEnvRequest
 from templatey.renderer import render_driver
+from templatey.templates import EnvFuncInvocationRef
 from templatey.templates import InjectedValue
 
 # Note: strings here will be escaped. InjectedValues may decide whether or not
@@ -237,6 +248,49 @@ class RenderEnvironment:
             template_config = template_class._templatey_config
             parsed_template_resource = parse(
                 template_text, template_config.interpolator)
+            segment_modifiers = template_class._templatey_segment_modifiers
+            part_index_counter = count()
+
+            parts_after_modification: list[
+                LiteralTemplateString
+                | InterpolatedSlot
+                | InterpolatedContent
+                | InterpolatedVariable
+                | InterpolatedFunctionCall] = []
+
+            for unmodified_part in parsed_template_resource.parts:
+                # The combinatorics here are gross, but this only runs once per
+                # template load, and not once per render, so at least there's
+                # that.
+                if isinstance(unmodified_part, str):
+                    for modifier in segment_modifiers:
+                        had_matches, after_mods = modifier.apply_and_flatten(
+                            unmodified_part)
+
+                        if had_matches:
+                            parts_after_modification.extend(
+                                _coerce_modified_segment(
+                                    modified_segment, part_index_counter)
+                                for modified_segment in after_mods)
+                            break
+
+                    else:
+                        # We still want to create a copy here, in case the
+                        # template loader is doing its own caching beyond what
+                        # we do within the env
+                        parts_after_modification.append(
+                            LiteralTemplateString(
+                                unmodified_part,
+                                part_index=next(part_index_counter)))
+
+                else:
+                    parts_after_modification.append(dc_replace(
+                        unmodified_part,
+                        part_index=next(part_index_counter)))
+
+            parsed_template_resource = dc_replace(
+                parsed_template_resource,
+                parts=tuple(parts_after_modification))
 
             if override_validation_strictness is None:
                 strict_mode = self.strict_interpolation_validation
@@ -475,3 +529,46 @@ def _infer_asyncness(env_function: EnvFunction | EnvFunctionAsync) -> bool:
     return (
         inspect.iscoroutinefunction(env_function)
         or inspect.isawaitable(env_function))
+
+
+def _coerce_modified_segment(
+        modified_segment:
+            str
+            | EnvFuncInvocationRef
+            | TemplateInstanceContentRef
+            | TemplateInstanceVariableRef,
+        part_index_counter: count,
+            ) -> (
+                LiteralTemplateString
+                | InterpolatedContent
+                | InterpolatedVariable
+                | InterpolatedFunctionCall):
+    """Converts the result of segment modification into an actual
+    parsed template resource part, including a part index.
+    """
+    if isinstance(modified_segment, str):
+        return LiteralTemplateString(str, part_index=next(part_index_counter))
+
+    elif isinstance(modified_segment, EnvFuncInvocationRef):
+        return InterpolatedFunctionCall(
+            part_index=next(part_index_counter),
+            name=modified_segment.name,
+            call_args=modified_segment.call_args,
+            call_args_exp=None,
+            call_kwargs=modified_segment.call_kwargs,
+            call_kwargs_exp=None)
+
+    elif isinstance(modified_segment, TemplateInstanceContentRef):
+        return InterpolatedContent(
+            part_index=next(part_index_counter),
+            name=modified_segment.name,
+            config=InterpolationConfig())
+
+    elif isinstance(modified_segment, TemplateInstanceVariableRef):
+        return InterpolatedVariable(
+            part_index=next(part_index_counter),
+            name=modified_segment.name,
+            config=InterpolationConfig())
+
+    else:
+        raise TypeError('Unknown modified segment type!', modified_segment)

--- a/src_py/templatey/parser.py
+++ b/src_py/templatey/parser.py
@@ -145,24 +145,24 @@ class InterpolatedFunctionCall:
 
 
 @dataclass(slots=True, frozen=True)
-class NestedContentReference:
+class TemplateInstanceContentRef:
     name: str
 
 
 @dataclass(slots=True, frozen=True)
-class NestedVariableReference:
+class TemplateInstanceVariableRef:
     name: str
 
 
 @dataclass(slots=True, frozen=True)
-class NestedDataReference:
+class TemplateInstanceDataRef:
     name: str
 
 
 _VALID_NESTED_REFS = {
-    'content': NestedContentReference,
-    'var': NestedVariableReference,
-    'data': NestedDataReference,}
+    'content': TemplateInstanceContentRef,
+    'var': TemplateInstanceVariableRef,
+    'data': TemplateInstanceDataRef,}
 
 
 def parse(
@@ -237,9 +237,9 @@ def parse(
 def _extract_nested_refs(
         value
         ) -> tuple[
-            set[NestedContentReference],
-            set[NestedVariableReference],
-            set[NestedDataReference]]:
+            set[TemplateInstanceContentRef],
+            set[TemplateInstanceVariableRef],
+            set[TemplateInstanceDataRef]]:
     """Call this to recursively extract all of the content and variable
     references contained within an environment function call.
     """
@@ -258,13 +258,13 @@ def _extract_nested_refs(
     else:
         nested_values = ()
 
-        if isinstance(value, NestedContentReference):
+        if isinstance(value, TemplateInstanceContentRef):
             content_refs.add(value)
 
-        elif isinstance(value, NestedVariableReference):
+        elif isinstance(value, TemplateInstanceVariableRef):
             var_refs.add(value)
 
-        elif isinstance(value, NestedDataReference):
+        elif isinstance(value, TemplateInstanceDataRef):
             data_refs.add(value)
 
     for nested_val in nested_values:

--- a/src_py/templatey/parser.py
+++ b/src_py/templatey/parser.py
@@ -10,12 +10,16 @@ from collections.abc import Collection
 from collections.abc import Generator
 from collections.abc import Iterator
 from collections.abc import Mapping
+from collections.abc import Sequence
 from dataclasses import dataclass
 from dataclasses import field
 from dataclasses import fields
 from functools import singledispatch
+from typing import Annotated
 from typing import Any
 from typing import cast
+
+from docnote import ClcNote
 
 from templatey.exceptions import DuplicateSlotName
 from templatey.exceptions import InvalidTemplateInterpolation
@@ -116,7 +120,7 @@ class InterpolatedVariable:
 class InterpolatedFunctionCall:
     part_index: int
     name: str
-    call_args: list[object] = field(compare=False)
+    call_args: Sequence[object] = field(compare=False)
     call_args_exp: object | None = field(compare=False)
     call_kwargs: dict[str, object] = field(compare=False)
     call_kwargs_exp: object | None = field(compare=False)
@@ -146,17 +150,35 @@ class InterpolatedFunctionCall:
 
 @dataclass(slots=True, frozen=True)
 class TemplateInstanceContentRef:
-    name: str
+    """Used to indicate that an environment function or segment
+    modification needs to reference a content parameter on the current
+    template instance being rendered.
+    """
+    name: Annotated[
+        str,
+        ClcNote('The name of the content parameter')]
 
 
 @dataclass(slots=True, frozen=True)
 class TemplateInstanceVariableRef:
-    name: str
+    """Used to indicate that an environment function or segment
+    modification needs to reference a variable parameter on the current
+    template instance being rendered.
+    """
+    name: Annotated[
+        str,
+        ClcNote('The name of the variable parameter')]
 
 
 @dataclass(slots=True, frozen=True)
 class TemplateInstanceDataRef:
-    name: str
+    """Used to indicate that an environment function (including one
+    injected via segment modification) needs to reference a template
+    data attribute on the current template instance being rendered.
+    """
+    name: Annotated[
+        str,
+        ClcNote('The name of the data attribute (the dataclass field name)')]
 
 
 _VALID_NESTED_REFS = {

--- a/src_py/templatey/renderer.py
+++ b/src_py/templatey/renderer.py
@@ -37,10 +37,10 @@ from templatey.parser import InterpolatedFunctionCall
 from templatey.parser import InterpolatedSlot
 from templatey.parser import InterpolatedVariable
 from templatey.parser import InterpolationConfig
-from templatey.parser import NestedContentReference
-from templatey.parser import NestedDataReference
-from templatey.parser import NestedVariableReference
 from templatey.parser import ParsedTemplateResource
+from templatey.parser import TemplateInstanceContentRef
+from templatey.parser import TemplateInstanceDataRef
+from templatey.parser import TemplateInstanceVariableRef
 from templatey.templates import ComplexContent
 from templatey.templates import InjectedValue
 from templatey.templates import TemplateConfig
@@ -866,7 +866,7 @@ def _recursively_coerce_func_execution_params[T: object](
         ) -> tuple[T]: ...
 @overload
 def _recursively_coerce_func_execution_params(
-        param_value: NestedContentReference | NestedVariableReference,
+        param_value: TemplateInstanceContentRef | TemplateInstanceVariableRef,
         *,
         template_instance: TemplateParamsInstance,
         unescaped_vars: _ParamLookup,
@@ -961,7 +961,7 @@ def _(
 # Note: I think there might be a bug in pyright re: singledispatch vs overloads
 @_recursively_coerce_func_execution_params.register  # type: ignore
 def _(
-        param_value: NestedContentReference,
+        param_value: TemplateInstanceContentRef,
         *,
         template_instance: TemplateParamsInstance,
         unescaped_vars: _ParamLookup,
@@ -978,7 +978,7 @@ def _(
 # Note: I think there might be a bug in pyright re: singledispatch vs overloads
 @_recursively_coerce_func_execution_params.register  # type: ignore
 def _(
-        param_value: NestedVariableReference,
+        param_value: TemplateInstanceVariableRef,
         *,
         template_instance: TemplateParamsInstance,
         unescaped_vars: _ParamLookup,
@@ -995,7 +995,7 @@ def _(
 # Note: I think there might be a bug in pyright re: singledispatch vs overloads
 @_recursively_coerce_func_execution_params.register  # type: ignore
 def _(
-        param_value: NestedDataReference,
+        param_value: TemplateInstanceDataRef,
         *,
         template_instance: TemplateParamsInstance,
         unescaped_vars: _ParamLookup,

--- a/src_py/templatey/templates.py
+++ b/src_py/templatey/templates.py
@@ -721,7 +721,7 @@ class ComplexContent(_ComplexContentBase):
             ''')]
 
 
-@dataclass(slots=True, kw_only=True)
+@dataclass(slots=True, frozen=True)
 class SegmentModifier:
     """Segment modifiers are a particularly powerful tool for reducing
     the verbosity of the actual template text. They allow you to modify
@@ -813,15 +813,16 @@ class SegmentModifierMatch:
         # has the added benefit of meaning we don't need to change behavior
         # between both cases.
         split_type_count = src_pattern.groups + 1
-        last_index = len(splits) - 1
 
         current_captures = []
         for index, post_split_segment in enumerate(splits):
             # This is always literal text, even if it's an empty string.
             if not index % split_type_count:
                 # Note that the zeroth and last index are always literal text,
-                # and are never preceeded or followed by a capture.
-                if 0 < index < last_index:
+                # and are never preceeded or followed by a capture. However,
+                # we still need to yield the preceeding match when we reach
+                # the end.
+                if 0 < index:
                     yield cls(captures=current_captures)
                     current_captures = []
 

--- a/src_py/templatey/templates.py
+++ b/src_py/templatey/templates.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import inspect
 import logging
+import re
 import sys
 import typing
 from collections import ChainMap
@@ -11,6 +12,7 @@ from collections.abc import Callable
 from collections.abc import Collection
 from collections.abc import Iterable
 from collections.abc import Mapping
+from collections.abc import Sequence
 from dataclasses import _MISSING_TYPE
 from dataclasses import Field
 from dataclasses import dataclass
@@ -39,6 +41,10 @@ from templatey._types import Slot
 from templatey._types import Var
 from templatey.interpolators import NamedInterpolator
 from templatey.parser import InterpolationConfig
+from templatey.parser import LiteralTemplateString
+from templatey.parser import TemplateInstanceContentRef
+from templatey.parser import TemplateInstanceDataRef
+from templatey.parser import TemplateInstanceVariableRef
 
 logger = logging.getLogger(__name__)
 
@@ -217,7 +223,19 @@ def template[T: type](  # noqa: PLR0913
         match_args: bool = True,
         kw_only: bool = False,
         slots: bool = True,
-        weakref_slot: bool = False
+        weakref_slot: bool = False,
+        segment_modifiers: Annotated[
+                Sequence[SegmentModifier] | None,
+                ClcNote('''An ordered sequence of ``SegmentModifier`` instances
+                    to apply to every literal string segment of the loaded
+                    template text.
+
+                    The modifiers will be applied in the order that they are
+                    declared. The first modifier to match the segment will
+                    short-circuit the remaining modifiers, regardless of
+                    whether or not it applies any changes.
+                    ''')
+            ] = None
         ) -> Callable[[T], T]:
     """This both transforms the decorated class into a stdlib dataclass
     and declares it as a templatey template.
@@ -229,6 +247,9 @@ def template[T: type](  # noqa: PLR0913
     free performance benefit. **If weakref support is required, be sure
     to pass ``weakref_slot=True``.
     """
+    if segment_modifiers is None:
+        segment_modifiers = []
+
     return functools.partial(
         make_template_definition,
         dataclass_kwargs={
@@ -244,7 +265,8 @@ def template[T: type](  # noqa: PLR0913
             'weakref_slot': weakref_slot
         },
         template_resource_locator=template_resource_locator,
-        template_config=config)
+        template_config=config,
+        segment_modifiers=segment_modifiers)
 
 
 @dataclass(frozen=True)
@@ -385,7 +407,8 @@ def make_template_definition[T: type](
         dataclass_kwargs: dict[str, bool],
         # Note: needs to be understandable by template loader
         template_resource_locator: object,
-        template_config: TemplateConfig
+        template_config: TemplateConfig,
+        segment_modifiers: Sequence[SegmentModifier]
         ) -> T:
     """Programmatically creates a template definition. Converts the
     requested class into a dataclass, passing along ``dataclass_kwargs``
@@ -551,6 +574,7 @@ def make_template_definition[T: type](
         forward_ref_lookup_key=template_forward_ref)
     converter_cls = namedtuple('TemplateyConverters', tuple(prerenderers))
     cls._templatey_prerenderers = converter_cls(**prerenderers)
+    cls._templatey_segment_modifiers = tuple(segment_modifiers)
 
     # Note: this needs to be the absolute last thing, because we need to fully
     # satisfy the intersectable interface before we can call it.
@@ -695,3 +719,168 @@ class ComplexContent(_ComplexContentBase):
             passed to the implemented ``flatten`` function during
             rendering.
             ''')]
+
+
+@dataclass(slots=True, kw_only=True)
+class SegmentModifier:
+    """Segment modifiers are a particularly powerful tool for reducing
+    the verbosity of the actual template text. They allow you to modify
+    literal string segments that match a particular pattern, replacing
+    that pattern with a different segment sequence.
+
+    For example, you could have a modifier that replaces every newline
+    in the segment with a call to an ``add_indentation`` environment
+    function:
+
+    Note that if you want access to any part of the matched pattern,
+    you must include it in a capture group:
+    """
+    pattern: re.Pattern
+    modifier: Callable[
+        [SegmentModifierMatch],
+        Sequence[
+            EnvFuncInvocationRef
+            | TemplateInstanceContentRef
+            | TemplateInstanceVariableRef
+            | str]]
+
+    def apply_and_flatten(
+            self,
+            literal_template_string: LiteralTemplateString
+            ) -> tuple[
+                bool,
+                list[
+                    str
+                    | EnvFuncInvocationRef
+                    | TemplateInstanceContentRef
+                    | TemplateInstanceVariableRef]]:
+        """This takes a literal template string segment and applies all
+        modifiers. This gets it ready to be converted into the actual
+        ParsedTemplateResource parts we need, but doesn't yet perform
+        the final conversion.
+
+        Returns a tuple of [had_matches, segments_after_modification]
+        """
+        after_modification: list[
+            str
+            | EnvFuncInvocationRef
+            | TemplateInstanceContentRef
+            | TemplateInstanceVariableRef] = []
+        had_matches = False
+        splits = self.pattern.split(literal_template_string)
+        for split_segment_or_modification in SegmentModifierMatch.from_splits(
+            self.pattern,
+            splits
+        ):
+            if isinstance(split_segment_or_modification, str):
+                # Here's where we filter out any empty strings. This also helps
+                # us re-normalize the output from re.split, so that we recover
+                # from the land of "let's use an empty string as a placeholder
+                # for anything we did implicitly"
+                if split_segment_or_modification:
+                    after_modification.append(split_segment_or_modification)
+            else:
+                had_matches = True
+                after_modification.extend(
+                    self.modifier(split_segment_or_modification))
+
+        return had_matches, after_modification
+
+
+@dataclass(slots=True, kw_only=True)
+class SegmentModifierMatch:
+    captures: Annotated[
+        list[str],
+        ClcNote(
+            '''The captures in a segment modifier match correspond to
+            the capture groups in the ``SegmentModifier`` pattern that
+            resulted in the match. If the pattern had zero match groups,
+            it will be an empty list. If it had one match group, it will
+            be a single-item list. Etc.
+
+            The ordering will be the same as the ordering of the groups
+            in the original pattern. Named groups are not supported.
+            ''')]
+
+    @classmethod
+    def from_splits(
+            cls,
+            src_pattern: re.Pattern,
+            splits: list[str]
+            ) -> Iterable[SegmentModifierMatch | str]:
+        # Note: the +1 is because we need to account for the literal strings
+        # in the pattern; otherwise the mod math doesn't work out! This also
+        # has the added benefit of meaning we don't need to change behavior
+        # between both cases.
+        split_type_count = src_pattern.groups + 1
+        last_index = len(splits) - 1
+
+        current_captures = []
+        for index, post_split_segment in enumerate(splits):
+            # This is always literal text, even if it's an empty string.
+            if not index % split_type_count:
+                # Note that the zeroth and last index are always literal text,
+                # and are never preceeded or followed by a capture.
+                if 0 < index < last_index:
+                    yield cls(captures=current_captures)
+                    current_captures = []
+
+                # Note: we're saving the "cull empty strings" bit for later;
+                # it makes the logic much cleaner to do one at a time
+                yield post_split_segment
+
+            else:
+                current_captures.append(post_split_segment)
+
+
+@dataclass(slots=True, init=False)
+class EnvFuncInvocationRef:
+    """Used to indicate that a segment modification needs to invoke an
+    environment function. Instantiate these like partials:
+
+    > Invocation example
+        def my_env_func(foo: str, *, bar: int) -> list[str]:
+            ...
+
+        EnvFuncInvocationRef('my_env_func', 'foo', bar=3)
+        EnvFuncInvocationRef(
+            'my_env_func',
+            # TemplateInstanceContentRef, TemplateInstanceDataRef, and
+            # TemplateInstanceVariableRef are all supported, including nested
+            # within containers
+            TemplateInstanceVariableRef('foo'),
+            bar=TemplateInstanceDataRef('bar'))
+
+    Note that unfortunately, until/unless higher-kinded type support is
+    added to python, these won't be able to type-check correctly.
+    """
+    name: str
+    call_args: tuple[
+        object
+        | TemplateInstanceContentRef
+        | TemplateInstanceDataRef
+        | TemplateInstanceVariableRef, ...]
+    call_kwargs: dict[
+        str,
+        object
+        | TemplateInstanceContentRef
+        | TemplateInstanceDataRef
+        | TemplateInstanceVariableRef]
+
+    def __init__(
+            self,
+            name: str,
+            /,
+            *call_args:
+                object
+                | TemplateInstanceContentRef
+                | TemplateInstanceDataRef
+                | TemplateInstanceVariableRef,
+            **call_kwargs:
+                object
+                | TemplateInstanceContentRef
+                | TemplateInstanceDataRef
+                | TemplateInstanceVariableRef):
+        self.name = name
+        self.call_args = call_args
+        self.call_kwargs = call_kwargs

--- a/tests_py/test_environments.py
+++ b/tests_py/test_environments.py
@@ -233,6 +233,17 @@ class TestRenderEnvironment:
         functions and cache whatever result is given by the loader. It
         must also, of course, call into parsing.
         """
+        # Doesn't need to be right, just needs to be a dataclass instance
+        mock_parse.return_value = ParsedTemplateResource(
+            parts=(),
+            variable_names=frozenset(),
+            content_names=frozenset(),
+            slot_names=frozenset(),
+            function_names=frozenset(),
+            data_names=frozenset(),
+            function_calls={},
+            slots={})
+
         @template(fake_template_config, 'fake')
         class FakeTemplate:
             foo: Var[str]
@@ -251,7 +262,9 @@ class TestRenderEnvironment:
             template_text='foobar',
             override_validation_strictness=None)
 
-        assert result is mock_parse.return_value
+        # Note that it won't be the actual object, because we created a copy
+        # while applying modifiers
+        assert result == mock_parse.return_value
         assert mock_parse.call_count == 1
         assert FakeTemplate in render_env._parsed_template_cache
         assert render_env._validate_env_functions.call_count == 1

--- a/tests_py/test_environments.py
+++ b/tests_py/test_environments.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import cast
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -26,6 +27,7 @@ from templatey.parser import parse
 from templatey.prebaked.loaders import DictTemplateLoader
 from templatey.renderer import FuncExecutionRequest
 from templatey.renderer import FuncExecutionResult
+from templatey.templates import SegmentModifier
 from templatey.templates import template
 
 from templatey_testutils import fake_template_config
@@ -269,6 +271,67 @@ class TestRenderEnvironment:
         assert FakeTemplate in render_env._parsed_template_cache
         assert render_env._validate_env_functions.call_count == 1
         assert render_env._validate_template_signature.call_count == 1
+
+    @patch('templatey.environments.parse', spec=parse)
+    def test_parse_and_cache_applies_modifiers(self, mock_parse):
+        """parse_and_cache must apply any modifiers on the template
+        to every string segment. They must be applied in order based on
+        the segment_modifiers sequence, and must short circuit on the
+        first match.
+        """
+        # Doesn't need to be right, just needs to be a dataclass instance
+        mock_parse.return_value = ParsedTemplateResource(
+            parts=(
+                LiteralTemplateString('foo ', part_index=0),
+                LiteralTemplateString('bar ', part_index=1),
+                LiteralTemplateString('baz', part_index=2)),
+            variable_names=frozenset(),
+            content_names=frozenset(),
+            slot_names=frozenset(),
+            function_names=frozenset(),
+            data_names=frozenset(),
+            function_calls={},
+            slots={})
+
+        seg_mods = [
+            SegmentModifier(
+                pattern=re.compile('f(o)(o)'),
+                modifier=
+                    lambda modifier_match: [
+                        f'mo{capture}'
+                        for capture in modifier_match.captures]),
+            SegmentModifier(
+                pattern=re.compile('foo|bar'),
+                modifier=lambda modifier_match: ['oof', 'rab'])]
+
+        @template(fake_template_config, 'fake', segment_modifiers=seg_mods)
+        class FakeTemplate:
+            foo: Var[str]
+
+        loader = DictTemplateLoader(templates={'fake': 'foobar'})
+        loader_mock = Mock(spec=loader.load_async, wraps=loader.load_async)
+        loader.load_async = loader_mock
+
+        render_env = RenderEnvironment(template_loader=loader)
+        render_env._validate_env_functions = Mock(
+            spec=render_env._validate_env_functions)
+        render_env._validate_template_signature = Mock(
+            spec=render_env._validate_template_signature)
+        result = render_env._parse_and_cache(
+            cast(type[TemplateIntersectable], FakeTemplate),
+            template_text='foobar',
+            override_validation_strictness=None)
+
+        assert result != mock_parse.return_value
+        assert result.part_count != mock_parse.return_value.part_count
+        assert result.parts == (
+            LiteralTemplateString('moo', part_index=0),
+            LiteralTemplateString('moo', part_index=1),
+            LiteralTemplateString(' ', part_index=2),
+            LiteralTemplateString('oof', part_index=3),
+            LiteralTemplateString('rab', part_index=4),
+            LiteralTemplateString(' ', part_index=5),
+            LiteralTemplateString('baz', part_index=6),)
 
     def test_validate_env_functions_matching_trivial(self):
         """_validate_env_functions must succeed if the template

--- a/tests_py/test_parser.py
+++ b/tests_py/test_parser.py
@@ -4,9 +4,9 @@ from templatey.parser import InterpolatedFunctionCall
 from templatey.parser import InterpolatedSlot
 from templatey.parser import InterpolatedVariable
 from templatey.parser import InterpolationConfig
-from templatey.parser import NestedContentReference
-from templatey.parser import NestedDataReference
-from templatey.parser import NestedVariableReference
+from templatey.parser import TemplateInstanceContentRef
+from templatey.parser import TemplateInstanceDataRef
+from templatey.parser import TemplateInstanceVariableRef
 from templatey.parser import parse
 
 
@@ -152,7 +152,7 @@ class TestParse:
         assert parsed.parts[0] == 'foo '
         assert parsed.parts[1] == InterpolatedSlot(
             part_index=1, name='bar',
-            params={'baz': NestedContentReference(name='baz')},
+            params={'baz': TemplateInstanceContentRef(name='baz')},
             config=InterpolationConfig())
         assert parsed.slot_names == frozenset({'bar'})
         assert parsed.content_names == frozenset({'baz'})
@@ -231,7 +231,7 @@ class TestParse:
             call_kwargs_exp=None,
             part_index=1,
             name='bar',
-            call_args=[NestedVariableReference(name='baz')],
+            call_args=[TemplateInstanceVariableRef(name='baz')],
             call_kwargs={})._matches(parsed.parts[1])
         assert not parsed.slot_names
         assert not parsed.content_names
@@ -250,7 +250,7 @@ class TestParse:
             call_kwargs_exp=None,
             part_index=1,
             name='bar',
-            call_args=[NestedDataReference(name='baz')],
+            call_args=[TemplateInstanceDataRef(name='baz')],
             call_kwargs={})._matches(parsed.parts[1])
         assert not parsed.slot_names
         assert not parsed.content_names
@@ -266,7 +266,7 @@ class TestParse:
         assert len(parsed.parts) == 2
         assert parsed.parts[0] == 'foo '
         assert InterpolatedFunctionCall(
-            call_args_exp=NestedVariableReference(name='baz'),
+            call_args_exp=TemplateInstanceVariableRef(name='baz'),
             call_kwargs_exp=None,
             part_index=1,
             name='bar',
@@ -286,7 +286,7 @@ class TestParse:
         assert parsed.parts[0] == 'foo '
         assert InterpolatedFunctionCall(
             call_args_exp=None,
-            call_kwargs_exp=NestedVariableReference(name='baz'),
+            call_kwargs_exp=TemplateInstanceVariableRef(name='baz'),
             part_index=1,
             name='bar',
             call_args=[],

--- a/tests_py/test_renderer.py
+++ b/tests_py/test_renderer.py
@@ -11,10 +11,10 @@ from templatey.parser import InterpolatedFunctionCall
 from templatey.parser import InterpolatedVariable
 from templatey.parser import InterpolationConfig
 from templatey.parser import LiteralTemplateString
-from templatey.parser import NestedContentReference
-from templatey.parser import NestedDataReference
-from templatey.parser import NestedVariableReference
 from templatey.parser import ParsedTemplateResource
+from templatey.parser import TemplateInstanceContentRef
+from templatey.parser import TemplateInstanceDataRef
+from templatey.parser import TemplateInstanceVariableRef
 from templatey.renderer import FuncExecutionResult
 from templatey.renderer import _apply_format
 from templatey.renderer import _capture_traceback
@@ -416,22 +416,26 @@ class TestRecursivelyCoerceFuncExecutionParams:
     @pytest.mark.parametrize(
         'before,expected_after',
         [
-            (NestedDataReference('data1'), '1data'),
-            ([NestedDataReference('data1')], ('1data',)),
-            ({'foo': NestedDataReference('data1')}, {'foo': '1data'}),
-            (['beep', NestedDataReference('data1')], ('beep', '1data')),
-            (NestedContentReference('foo'), 'oof'),
-            ([NestedContentReference('foo')], ('oof',)),
-            ({'foo': NestedContentReference('foo')}, {'foo': 'oof'}),
-            (['beep', NestedContentReference('foo')], ('beep', 'oof')),
-            (NestedVariableReference('bar'), 'rab'),
-            ([NestedVariableReference('bar')], ('rab',)),
-            ({'bar': NestedVariableReference('bar')}, {'bar': 'rab'}),
-            (['beep', NestedVariableReference('bar')], ('beep', 'rab')),
-            ([NestedContentReference('foo'), NestedVariableReference('bar')],
+            (TemplateInstanceDataRef('data1'), '1data'),
+            ([TemplateInstanceDataRef('data1')], ('1data',)),
+            ({'foo': TemplateInstanceDataRef('data1')}, {'foo': '1data'}),
+            (['beep', TemplateInstanceDataRef('data1')], ('beep', '1data')),
+            (TemplateInstanceContentRef('foo'), 'oof'),
+            ([TemplateInstanceContentRef('foo')], ('oof',)),
+            ({'foo': TemplateInstanceContentRef('foo')}, {'foo': 'oof'}),
+            (['beep', TemplateInstanceContentRef('foo')], ('beep', 'oof')),
+            (TemplateInstanceVariableRef('bar'), 'rab'),
+            ([TemplateInstanceVariableRef('bar')], ('rab',)),
+            ({'bar': TemplateInstanceVariableRef('bar')}, {'bar': 'rab'}),
+            (['beep', TemplateInstanceVariableRef('bar')], ('beep', 'rab')),
+            (
+                [
+                    TemplateInstanceContentRef('foo'),
+                    TemplateInstanceVariableRef('bar')],
                 ('oof', 'rab'))])
     def test_recursive_nested_reference(self, before, expected_after):
-        """``NestedContentReference``s and ``NestedVariableReference``s,
+        """``TemplateInstanceContentRef``s and
+        ``TemplateInstanceVariableRef``s,
         including those nested inside collections, must correctly be
         coerced (dereferenced).
         """

--- a/tests_py/test_templates.py
+++ b/tests_py/test_templates.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections import defaultdict
 from dataclasses import FrozenInstanceError
 from dataclasses import is_dataclass
@@ -17,6 +18,7 @@ from templatey._types import TemplateIntersectable
 from templatey._types import Var
 from templatey._types import is_template_class
 from templatey._types import is_template_instance
+from templatey.templates import SegmentModifier
 from templatey.templates import make_template_definition
 from templatey.templates import template
 
@@ -116,6 +118,29 @@ class TestMakeTemplateDefinition:
             template_config=fake_template_config,
             segment_modifiers=[])
         assert is_template_class(retval)
+
+    def test_segment_modifiers_assigned(self):
+        """Segment modifiers, if defined, must be added to the template
+        class.
+        """
+        class Foo:
+            foo: Var[str]
+
+        modifiers = [
+            SegmentModifier(
+                pattern=re.compile(''),
+                modifier=lambda modifier_match: [])]
+
+        retval = make_template_definition(
+            Foo,
+            dataclass_kwargs={},
+            template_resource_locator=object(),
+            template_config=fake_template_config,
+            segment_modifiers=modifiers)
+        assert hasattr(retval, '_templatey_segment_modifiers')
+        assert cast(
+            type[TemplateIntersectable], retval
+        )._templatey_segment_modifiers == tuple(modifiers)
 
     def test_closure_resolution_works(self):
         """Another template referenced as a slot must successfully

--- a/tests_py/test_templates.py
+++ b/tests_py/test_templates.py
@@ -113,7 +113,8 @@ class TestMakeTemplateDefinition:
             Foo,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config)
+            template_config=fake_template_config,
+            segment_modifiers=[])
         assert is_template_class(retval)
 
     def test_closure_resolution_works(self):
@@ -134,7 +135,8 @@ class TestMakeTemplateDefinition:
             Bar,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config)
+            template_config=fake_template_config,
+            segment_modifiers=[])
         assert is_template_class(retval)
 
     def test_forward_ref_works(self):
@@ -152,7 +154,8 @@ class TestMakeTemplateDefinition:
             Bar,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config))
+            template_config=fake_template_config,
+            segment_modifiers=[]))
         assert is_template_class(retval)
 
         assert len(retval._templatey_signature._pending_ref_lookup) == 1
@@ -192,7 +195,8 @@ class TestMakeTemplateDefinition:
             Bar,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config))
+            template_config=fake_template_config,
+            segment_modifiers=[]))
         assert is_template_class(retval)
 
         assert len(retval._templatey_signature._pending_ref_lookup) == 1
@@ -260,7 +264,8 @@ class TestMakeTemplateDefinition:
             Baz,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config))
+            template_config=fake_template_config,
+            segment_modifiers=[]))
         assert is_template_class(retval)
 
         assert len(retval._templatey_signature._pending_ref_lookup) == 1
@@ -295,7 +300,8 @@ class TestMakeTemplateDefinition:
             Foo,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config))
+            template_config=fake_template_config,
+            segment_modifiers=[]))
         assert is_template_class(retval)
         assert len(retval._templatey_signature._pending_ref_lookup) == 0
         forward_ref_registry = PENDING_FORWARD_REFS.get()
@@ -318,7 +324,8 @@ class TestMakeTemplateDefinition:
             Bar,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config))
+            template_config=fake_template_config,
+            segment_modifiers=[]))
         assert is_template_class(retval)
 
         assert len(retval._templatey_signature._pending_ref_lookup) == 1
@@ -357,7 +364,8 @@ class TestMakeTemplateDefinition:
             FakeTemplate,
             dataclass_kwargs={},
             template_resource_locator='my_special_locator',
-            template_config=fake_template_config))
+            template_config=fake_template_config,
+            segment_modifiers=[]))
         assert retval._templatey_resource_locator == 'my_special_locator'
         assert retval._templatey_config is fake_template_config
 
@@ -378,7 +386,8 @@ class TestMakeTemplateDefinition:
             FakeTemplate,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config))
+            template_config=fake_template_config,
+            segment_modifiers=[]))
         signature = retval._templatey_signature
 
         assert len(signature.slot_names) == 1
@@ -405,7 +414,8 @@ class TestMakeTemplateDefinition:
             FakeTemplate,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config))
+            template_config=fake_template_config,
+            segment_modifiers=[]))
         signature = retval._templatey_signature
 
         assert len(signature.slot_names) == 1
@@ -435,7 +445,8 @@ class TestMakeTemplateDefinition:
             FakeTemplate,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config))
+            template_config=fake_template_config,
+            segment_modifiers=[]))
         signature = retval._templatey_signature
 
         assert len(signature.slot_names) == 2
@@ -528,7 +539,8 @@ class TestMakeTemplateDefinition:
             FakeTemplate,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config))
+            template_config=fake_template_config,
+            segment_modifiers=[]))
         signature = retval._templatey_signature
 
         assert len(signature.var_names) == 1
@@ -544,7 +556,8 @@ class TestMakeTemplateDefinition:
             FakeTemplate,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config))
+            template_config=fake_template_config,
+            segment_modifiers=[]))
         signature = retval._templatey_signature
 
         assert len(signature.data_names) == 1
@@ -562,7 +575,8 @@ class TestMakeTemplateDefinition:
             FakeTemplate,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config))
+            template_config=fake_template_config,
+            segment_modifiers=[]))
         signature = retval._templatey_signature
 
         assert len(signature.content_names) == 1
@@ -579,7 +593,8 @@ class TestMakeTemplateDefinition:
             FakeTemplate,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config)
+            template_config=fake_template_config,
+            segment_modifiers=[])
         assert is_dataclass(retval)
 
     def test_supports_passthrough(self):
@@ -593,7 +608,8 @@ class TestMakeTemplateDefinition:
             FakeTemplate,
             dataclass_kwargs={'frozen': True, 'slots': True},
             template_resource_locator=object(),
-            template_config=fake_template_config)
+            template_config=fake_template_config,
+            segment_modifiers=[])
 
         instance = template_cls(foo='foo')  # type: ignore
         with pytest.raises(FrozenInstanceError):
@@ -620,7 +636,8 @@ class TestMakeTemplateDefinition:
             FakeTemplate,
             dataclass_kwargs={},
             template_resource_locator=object(),
-            template_config=fake_template_config))
+            template_config=fake_template_config,
+            segment_modifiers=[]))
         signature = retval._templatey_signature
 
         assert len(signature.slot_names) == 1


### PR DESCRIPTION
# Summary

The text of a template should be as expressive as possible. You can imagine plenty of situations where this expressiveness stands at odds with neatness when the template is rendered out within a slot. A prime example would be indentation: if you, for example, want to have a pretty-formatted HTML document, your options are limited:

+ include a variable/content/function call at the start of every line in the template text, injecting the required indentation (extremely verbose and non-expressive)
+ create separate templates for every indentation level (defeats the purpose of reusable components)
+ some other, similarly suboptimal non-solution

This PR allows you a new option, which preserves the expressiveness of the template text itself, while affording the versatility of the first of those options: template segment modifiers.

When specifying a template segment modifier, you can perform a regex match and capture on every literal string segment in the template, and then modify and/or replace that string. In the indentation example, this allows you to modify each newline character with a newline, followed by a variable/content/function call to include the required indentation.

This could still use some quality of life improvements (for example, a stacking template context system, allowing easy bookkeeping of the indentation level), but it's already a significant improvement (and would be a necessary prerequisite for any more advanced solutions, anyways).

# Testing

This adds both unit tests and an integration test for the feature.