### PR TITLE
Improve handling of errors in render loop

### DIFF
--- a/src_py/templatey/_error_collector.py
+++ b/src_py/templatey/_error_collector.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from dataclasses import field
+
+DEFAULT_MAX_ERRORS = 1000
+
+
+@dataclass(slots=True, kw_only=True)
+class ErrorCollector(list[Exception]):
+    """The ``ErrorCollector`` is a list subclass with some minor
+    improvements to help avoid getting into infinite loops due to
+    faulty error handling.
+    """
+
+    # The lambda here is so that the DEFAULT_MAX_ERRORS can be changed at
+    # runtime by library consumers
+    max_errors: int = field(default_factory=lambda: DEFAULT_MAX_ERRORS)
+
+    def append(self, obj: Exception):
+        list.append(self, obj)
+
+        if len(self) > self.max_errors:
+            raise ExceptionGroup(
+                'Max number of collected errors exceeded!',
+                self)
+
+    def extend(self, objs: Iterable[Exception]):
+        list.extend(self, objs)
+
+        if len(self) > self.max_errors:
+            raise ExceptionGroup(
+                'Max number of collected errors exceeded!',
+                self)

--- a/src_py/templatey/environments.py
+++ b/src_py/templatey/environments.py
@@ -19,6 +19,7 @@ except ImportError:
 
 from templatey._bootstrapping import PARSED_EMPTY_TEMPLATE
 from templatey._bootstrapping import EmptyTemplate
+from templatey._error_collector import ErrorCollector
 from templatey._types import TemplateClass
 from templatey._types import TemplateIntersectable
 from templatey._types import TemplateParamsInstance
@@ -429,7 +430,7 @@ class RenderEnvironment:
             template_instance: TemplateParamsInstance
             ) -> str:
         output = []
-        error_collector = []
+        error_collector = ErrorCollector()
         for env_request in render_driver(
             template_instance, output, error_collector
         ):
@@ -470,7 +471,7 @@ class RenderEnvironment:
             template_instance: TemplateParamsInstance
             ) -> str:
         output = []
-        error_collector = []
+        error_collector = ErrorCollector()
         for env_request in render_driver(
             template_instance, output, error_collector
         ):

--- a/src_py/templatey/renderer.py
+++ b/src_py/templatey/renderer.py
@@ -20,6 +20,7 @@ from typing import overload
 
 from templatey._bootstrapping import EMPTY_TEMPLATE_INSTANCE
 from templatey._bootstrapping import EMPTY_TEMPLATE_XABLE
+from templatey._error_collector import ErrorCollector
 from templatey._provenance import Provenance
 from templatey._provenance import ProvenanceNode
 from templatey._signature import TemplateSignature
@@ -85,7 +86,7 @@ class RenderEnvRequest:
     """
     to_load: Collection[type[TemplateParamsInstance]]
     to_execute: Collection[FuncExecutionRequest]
-    error_collector: list[Exception]
+    error_collector: ErrorCollector
 
     # These store results; we're adding them inplace instead of needing to
     # merge them later on
@@ -102,7 +103,7 @@ class RenderEnvRequest:
 def render_driver(  # noqa: C901, PLR0912, PLR0915
         template_instance: TemplateParamsInstance,
         output: list[str],
-        error_collector: list[Exception]
+        error_collector: ErrorCollector
         ) -> Iterable[RenderEnvRequest]:
     """This is a shared method for driving rendering, used by both async
     and sync renderers. It mutates the output list inplace, and yields
@@ -437,7 +438,7 @@ class _PrepopulationBatch:
             self,
             template_preload:
                 dict[TemplateClass, ParsedTemplateResource],
-            error_collector: list[Exception],
+            error_collector: ErrorCollector,
             ) -> _PrepopulationBatch | None:
         function_backlog = []
         injection_provenance = self.injection_provenance
@@ -542,7 +543,7 @@ class _RenderContext:
     """
     template_preload: dict[TemplateClass, ParsedTemplateResource]
     function_precall: dict[_PrecallCacheKey, FuncExecutionResult]
-    error_collector: list[Exception]
+    error_collector: ErrorCollector
 
     def prepopulate(
             self,
@@ -636,7 +637,7 @@ def _render_complex_content(
         template_config: TemplateConfig,
         interpolation_config: InterpolationConfig,
         prerenderers: NamedTuple,
-        error_collector: list[Exception],
+        error_collector: ErrorCollector,
         ) -> Iterable[str]:
     try:
         extracted_vars = {
@@ -684,7 +685,7 @@ def _build_render_frame_for_func_result(  # noqa: C901
         abstract_call: InterpolatedFunctionCall,
         execution_result: FuncExecutionResult,
         template_config: TemplateConfig,
-        error_collector: list[Exception]
+        error_collector: ErrorCollector
         ) -> _RenderStackFrame | None:
     """This constructs a _RenderNode for the given execution result and
     returns it (or None, if there was an error).
@@ -767,7 +768,7 @@ class _ParamLookup(Mapping[str, object]):
     rendering.
     """
     provenance: Provenance
-    error_collector: list[Exception]
+    error_collector: ErrorCollector
     placeholder_on_error: object
     lookup: Callable[[str], object]
     param_flavor: InterfaceAnnotationFlavor
@@ -777,7 +778,7 @@ class _ParamLookup(Mapping[str, object]):
             provenance: Provenance,
             template_preload: dict[TemplateClass, ParsedTemplateResource],
             param_flavor: InterfaceAnnotationFlavor,
-            error_collector: list[Exception],
+            error_collector: ErrorCollector,
             placeholder_on_error: object):
         self.error_collector = error_collector
         self.placeholder_on_error = placeholder_on_error

--- a/tests_py/test_renderer.py
+++ b/tests_py/test_renderer.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from templatey._bootstrapping import EMPTY_TEMPLATE_INSTANCE
+from templatey._error_collector import ErrorCollector
 from templatey.interpolators import NamedInterpolator
 from templatey.parser import InterpolatedFunctionCall
 from templatey.parser import InterpolatedVariable
@@ -89,7 +90,7 @@ class TestRenderDriver:
             autospec=True,
         ):
             parts_output = []
-            error_collector = []
+            error_collector = ErrorCollector()
             __ = [
                 *render_driver(FakeTemplate(), parts_output, error_collector)]
 
@@ -150,7 +151,7 @@ class TestRenderDriver:
             return_value=fake_cache_key
         ):
             parts_output = []
-            error_collector = []
+            error_collector = ErrorCollector()
             __ = [
                 *render_driver(FakeTemplate(), parts_output, error_collector)]
 
@@ -201,7 +202,7 @@ class TestRenderDriver:
             autospec=True,
         ):
             parts_output = []
-            error_collector = []
+            error_collector = ErrorCollector()
             __ = [
                 *render_driver(
                     FakeTemplate(var1='1var'),
@@ -225,7 +226,7 @@ class TestRenderContext:
         ctx = _RenderContext(
             template_preload={},
             function_precall={},
-            error_collector=[])
+            error_collector=ErrorCollector())
 
         request_count = 0
         for request in ctx.prepopulate(FakeTemplate(var1='foo')):
@@ -259,7 +260,7 @@ class TestRenderContext:
         ctx = _RenderContext(
             template_preload={},
             function_precall={},
-            error_collector=[])
+            error_collector=ErrorCollector())
         fake_interpolated_call = InterpolatedFunctionCall(
             call_args_exp=None,
             call_kwargs_exp=None,
@@ -319,7 +320,7 @@ class TestRenderContext:
         ctx = _RenderContext(
             template_preload={},
             function_precall={},
-            error_collector=[])
+            error_collector=ErrorCollector())
         fake_interpolated_call = InterpolatedFunctionCall(
             call_args_exp=['oof'],
             call_kwargs_exp={'baz': 'zab'},


### PR DESCRIPTION
# Summary

Currently, certain kinds of errors can cause infinite loops during rendering, because the error collector swallows errors without advancing the relevant indices. This is a **massive** problem when developing templates.

This PR substantially improves the error handling by:

1. Putting index advancement within ``finally:`` blocks
2. Adding a dedicated ``ErrorCollector`` class that has a maximum error capacity as a fallback