### PR TITLE
Update API to use ``template_field`` instead of ``param``

### DIFF
--- a/src_py/templatey/__init__.py
+++ b/src_py/templatey/__init__.py
@@ -9,24 +9,27 @@ from templatey._types import Slot
 from templatey._types import Var
 from templatey.environments import RenderEnvironment
 from templatey.templates import ComplexContent
+from templatey.templates import FieldConfig
 from templatey.templates import InjectedValue
 from templatey.templates import TemplateConfig
-from templatey.templates import param
+from templatey.templates import param  #  type: ignore  # noqa: F401
 from templatey.templates import template
+from templatey.templates import template_field
 
 __all__ = [
     'ComplexContent',
     'Content',
     'DynamicClassSlot',
+    'FieldConfig',
     'InjectedValue',
     'RenderEnvironment',
     'Slot',
     'TemplateConfig',
     'Var',
     'anchor_closure_scope',
-    'param',
     'prebaked',
     'template',
+    'template_field',
 ]
 
 

--- a/tests_py/test_e2e.py
+++ b/tests_py/test_e2e.py
@@ -11,10 +11,11 @@ import pytest
 
 from templatey import Content
 from templatey import DynamicClassSlot
+from templatey import FieldConfig
 from templatey import Slot
 from templatey import Var
-from templatey import param
 from templatey import template
+from templatey import template_field
 from templatey.environments import RenderEnvironment
 from templatey.interpolators import NamedInterpolator
 from templatey.parser import TemplateInstanceDataRef
@@ -596,15 +597,15 @@ class TestApiE2E:
 
         @template(html, 'test_template')
         class RendererTemplate:
-            good_content: Content[bool] = param(
+            good_content: Content[bool] = template_field(FieldConfig(
                 prerenderer=
-                    lambda value: '<p>yes</p>' if value else '<p>no</p>')
-            borderline_var: Var[bool] = param(
-                prerenderer=lambda value: '<yes>' if value else '<no>')
-            omitted_var_value: Var[str] = param(
-                prerenderer=lambda value: None)
-            illegal_content_tag: Content[str] = param(
-                prerenderer=lambda value: 'caught!')
+                    lambda value: '<p>yes</p>' if value else '<p>no</p>'))
+            borderline_var: Var[bool] = template_field(FieldConfig(
+                prerenderer=lambda value: '<yes>' if value else '<no>'))
+            omitted_var_value: Var[str] = template_field(FieldConfig(
+                prerenderer=lambda value: None))
+            illegal_content_tag: Content[str] = template_field(FieldConfig(
+                prerenderer=lambda value: 'caught!'))
 
         render_env = RenderEnvironment(
             env_functions=(),


### PR DESCRIPTION
# Summary

Currently, the API is set up so that templates needing to configure individual fields use a ``param`` field specifier (as opposed to ``dataclass.field``), and each individual config value is passed to ``param`` as a keyword argument and then set as an individual metadata key.

This presents some significant challenges for future maintenance:

+ any new parameters will need an updated ``param`` signature, which can get complicated, since it already needs to mirror the ``field()`` signature
+ users that want to combine the template with some other use for the dataclass (which also needs to set metadata) will need to set one metadata key per config value
+ the ``param`` signature is already pretty big, and this would only make it bigger

This PR transitions the API to instead use a single positional-only argument for a ``FieldConfig`` instance under a single metadata key.

# Side notes

This deprecates the existing ``param`` approach and marks it to be removed from docs, but it preserves the exports, so that neither test code nor downstream code breaks. Libraries should update their code to the new way as soon as possible (though I'm pretty sure Taev is the only one actually using templatey!).

# Testing

I updated an e2e test to verify the new approach works. I also verified (manually) that the old ``param`` approach still works, even though it's deprecated.