### PR TITLE
QOL: add an importable instance of ``InlineStringTemplateLoader`` for convenience

### DIFF
--- a/src_py/templatey/prebaked/loaders.py
+++ b/src_py/templatey/prebaked/loaders.py
@@ -11,7 +11,7 @@ except ImportError:
     if typing.TYPE_CHECKING:
         import anyio
 
-from docnote import ClcNote
+from docnote import Note
 
 from templatey._types import TemplateClassInstance
 from templatey.environments import AsyncTemplateLoader
@@ -41,17 +41,23 @@ class InlineStringTemplateLoader(
         return template_resource_locator
 
 
+INLINE_STRING_LOADER: Annotated[
+        InlineStringTemplateLoader,
+        Note('''An ``InlineStringTemplateLoader`` instance, provided for
+            convenience, so that libraries shipping their own inline templates
+            don't need to create one.''')
+    ] = InlineStringTemplateLoader()
+
+
 class DictTemplateLoader[L: object](
         AsyncTemplateLoader[L], SyncTemplateLoader[L]):
     """A barebones template loader that simply loads templates from a
     dictionary based on whatever key you supply.
     """
     lookup: Annotated[dict[L, str],
-        ClcNote('''
-            Provides direct access to the template lookup. Store literal
+        Note('''Provides direct access to the template lookup. Store literal
             template text here using whatever key matches the resource locator
-            used on your template definitions.
-            ''')]
+            used on your template definitions.''')]
 
     def __init__(self, templates: dict[L, str] | None = None):
         if templates is None:

--- a/src_py/templatey/prebaked/loaders.py
+++ b/src_py/templatey/prebaked/loaders.py
@@ -41,7 +41,7 @@ class InlineStringTemplateLoader(
         return template_resource_locator
 
 
-INLINE_STRING_LOADER: Annotated[
+INLINE_TEMPLATE_LOADER: Annotated[
         InlineStringTemplateLoader,
         Note('''An ``InlineStringTemplateLoader`` instance, provided for
             convenience, so that libraries shipping their own inline templates


### PR DESCRIPTION
# Summary

Currently, libraries wishing to use the ``InlineStringTemplateLoader`` to ship templates with inline text need to always create their own instance in order to use the loader. But there's no configuration needed for the loader, so there's no real reason for it; in the end, you just end up creating a ``INLINE_TEMPLATE_LOADER`` constant for every library wanting to ship templates. So this PR adds exactly such a constant within the prebaked loaders, so it can be imported directly instead of recreated repeatedly.